### PR TITLE
Create pieni-sali.csv

### DIFF
--- a/programme/models/paikkala_data/tampere-talo/pieni-sali.csv
+++ b/programme/models/paikkala_data/tampere-talo/pieni-sali.csv
@@ -1,42 +1,42 @@
 zone,row,start,end
-Aitio 2 vasen,1,1,4
-Aitio 2 vasen,2,5,9
-Aitio 2 vasen,3,10,14
-Aitio 3 vasen,1,1,7
-Aitio 3 vasen,2,8,15
-Aitio 3 vasen,3,16,23
-Aitio 4 vasen,1,1,10
-Aitio 4 vasen,2,11,21
-Aitio 4 vasen,3,22,32
-Permanto oikea,2,23,34
-Permanto vasen,2,35,45
-Permanto oikea,3,46,56
-Permanto vasen,3,57,67
-Permanto oikea,4,68,79
-Permanto vasen,4,80,90
-Permanto oikea,5,91,101
-Permanto vasen,5,102,112
-Permanto oikea,6,113,124
-Permanto vasen,6,125,135
-Permanto oikea,7,136,146
-Permanto vasen,7,147,157
-Permanto oikea,8,158,169
-Permanto vasen,8,170,180
-Permanto oikea,9,181,191
-Permanto vasen,9,192,202
-Permanto oikea,10,203,214
-Permanto vasen,10,215,225
-Permanto oikea,11,226,236
-Permanto vasen,11,237,247
-Permanto oikea,12,248,259
-Permanto vasen,12,260,270
-Permanto oikea,13,271,281
-Permanto vasen,13,282,292
-Permanto oikea,14,293,304
-Permanto vasen,14,305,315
-Permanto oikea,15,316,326
-Permanto vasen,15,327,337
-Permanto oikea,16,338,349
-Permanto vasen,16,350,360
-Permanto oikea,17,361,371
-Permanto vasen,17,372,382
+Aitio 2 vasen (2. krs),1,1,4
+Aitio 2 vasen (2. krs),2,5,9
+Aitio 2 vasen (2. krs),3,10,14
+Aitio 3 vasen (2. krs),1,1,7
+Aitio 3 vasen (2. krs),2,8,15
+Aitio 3 vasen (2. krs),3,16,23
+Aitio 4 vasen (2. krs),1,1,10
+Aitio 4 vasen (2. krs),2,11,21
+Aitio 4 vasen (2. krs),3,22,32
+Permanto oikea (2. krs),2,23,34
+Permanto vasen (2. krs),2,35,45
+Permanto oikea (2. krs),3,46,56
+Permanto vasen (2. krs),3,57,67
+Permanto oikea (2. krs),4,68,79
+Permanto vasen (2. krs),4,80,90
+Permanto oikea (2. krs),5,91,101
+Permanto vasen (2. krs),5,102,112
+Permanto oikea (2. krs),6,113,124
+Permanto vasen (2. krs),6,125,135
+Permanto oikea (2. krs),7,136,146
+Permanto vasen (2. krs),7,147,157
+Permanto oikea (2. krs),8,158,169
+Permanto vasen (2. krs),8,170,180
+Permanto oikea (2. krs),9,181,191
+Permanto vasen (2. krs),9,192,202
+Permanto oikea (2. krs),10,203,214
+Permanto vasen (2. krs),10,215,225
+Permanto oikea (2. krs),11,226,236
+Permanto vasen (2. krs),11,237,247
+Permanto oikea (2. krs),12,248,259
+Permanto vasen (2. krs),12,260,270
+Permanto oikea (2. krs),13,271,281
+Permanto vasen (2. krs),13,282,292
+Permanto oikea (2. krs),14,293,304
+Permanto vasen (2. krs),14,305,315
+Permanto oikea (2. krs),15,316,326
+Permanto vasen (2. krs),15,327,337
+Permanto oikea (2. krs),16,338,349
+Permanto vasen (2. krs),16,350,360
+Permanto oikea (2. krs),17,361,371
+Permanto vasen (2. krs),17,372,382

--- a/programme/models/paikkala_data/tampere-talo/pieni-sali.csv
+++ b/programme/models/paikkala_data/tampere-talo/pieni-sali.csv
@@ -1,0 +1,42 @@
+zone,row,start,end
+Aitio 2 vasen,1,1,4
+Aitio 2 vasen,2,5,9
+Aitio 2 vasen,3,10,14
+Aitio 3 vasen,1,1,7
+Aitio 3 vasen,2,8,15
+Aitio 3 vasen,3,16,23
+Aitio 4 vasen,1,1,10
+Aitio 4 vasen,2,11,21
+Aitio 4 vasen,3,22,32
+Permanto oikea,2,23,34
+Permanto vasen,2,35,45
+Permanto oikea,3,46,56
+Permanto vasen,3,57,67
+Permanto oikea,4,68,79
+Permanto vasen,4,80,90
+Permanto oikea,5,91,101
+Permanto vasen,5,102,112
+Permanto oikea,6,113,124
+Permanto vasen,6,125,135
+Permanto oikea,7,136,146
+Permanto vasen,7,147,157
+Permanto oikea,8,158,169
+Permanto vasen,8,170,180
+Permanto oikea,9,181,191
+Permanto vasen,9,192,202
+Permanto oikea,10,203,214
+Permanto vasen,10,215,225
+Permanto oikea,11,226,236
+Permanto vasen,11,237,247
+Permanto oikea,12,248,259
+Permanto vasen,12,260,270
+Permanto oikea,13,271,281
+Permanto vasen,13,282,292
+Permanto oikea,14,293,304
+Permanto vasen,14,305,315
+Permanto oikea,15,316,326
+Permanto vasen,15,327,337
+Permanto oikea,16,338,349
+Permanto vasen,16,350,360
+Permanto oikea,17,361,371
+Permanto vasen,17,372,382


### PR DESCRIPTION
Pienen salin paikkadata, Tracon 2022.

Datasta puuttuvat tarkoituksella seuraavat paikat, jotka on varattu muihin tarkoituksiin:
- aitio 1
- permannon rivi 1
- pyörätuolipaikat rivin 18 takana
- pienen salin parvi