### PR TITLE
Update iso-sali.csv

### DIFF
--- a/programme/models/paikkala_data/tampere-talo/iso-sali.csv
+++ b/programme/models/paikkala_data/tampere-talo/iso-sali.csv
@@ -10,12 +10,18 @@ Etupermanto vasen (2. krs),B6,217,225
 Etupermanto vasen (2. krs),A7,247,259
 Etupermanto vasen (2. krs),B7,260,268
 Etupermanto vasen (2. krs),A8,291,303
-Etupermanto vasen (2. krs),A9,328,341
-Etupermanto vasen (2. krs),A10,356,369
-Etupermanto vasen (2. krs),A11,384,396
-Etupermanto vasen (2. krs),A12,410,422
+Etupermanto vasen (2. krs),B8,308,312
+Etupermanto vasen (2. krs),A9,328,332
+Etupermanto vasen (2. krs),A9,336,341
+Etupermanto vasen (2. krs),A10,356,360
+Etupermanto vasen (2. krs),A10,365,369
+Etupermanto vasen (2. krs),A11,384,387
+Etupermanto vasen (2. krs),A11,393,396
+Etupermanto vasen (2. krs),A12,410,414
+Etupermanto vasen (2. krs),A12,419,422
 Etupermanto vasen (2. krs),A13,436,447
 Etupermanto vasen (2. krs),A14,460,471
+Etupermanto vasen (2. krs),A15,489,494
 Takapermanto vasen (2. krs),A16,11,21
 Takapermanto vasen (2. krs),A17,35,47
 Takapermanto vasen (2. krs),B18,90,104
@@ -51,6 +57,7 @@ Etupermanto oikea (2. krs),A11,370,383
 Etupermanto oikea (2. krs),A12,397,409
 Etupermanto oikea (2. krs),A13,423,435
 Etupermanto oikea (2. krs),A14,448,459
+Etupermanto oikea (2. krs),A15,472,479
 Takapermanto oikea (2. krs),A16,1,10
 Takapermanto oikea (2. krs),A17,22,34
 Takapermanto oikea (2. krs),B18,48,62
@@ -69,10 +76,11 @@ Takapermanto oikea (2. krs),B24,375,384
 Takapermanto oikea (2. krs),A24,385,401
 Takapermanto oikea (2. krs),B25,428,436
 Takapermanto oikea (2. krs),A25,437,453
+Aitio A oikea (2. krs),B9,1,10
 Aitio A oikea (2. krs),B10,11,21
 Aitio A oikea (2. krs),B11,22,32
 Aitio A oikea (2. krs),B12,33,45
-Aitio A oikea (2. krs),B13,46,60
+Aitio A oikea (2. krs),B13,47,60
 Aitio A oikea (2. krs),B14,61,76
 Aitio A oikea (2. krs),B15,77,91
 Etuparveke vasen (3. krs),A8,61,69


### PR DESCRIPTION
Updated customer seating for Tracon 2022.

- Some seats on rows A9-A12 are reserved for cameras.
- We now have a better understanding of which seats on A15 are reserved for cameras; the rest of the seats are now available for customers.
- Treta has disabled one seat on row A13 in aitio A
- Row A9 in aitio A is no longer needed for Tracon's cameras - converted to customer seats
- Row B8 left is no longer needed for Tracon's stream - converted to customer seats