### PR TITLE
chore(shumicon2023): add paikkala data for Stoa

### DIFF
--- a/programme/models/paikkala_data/kulttuurikeskus-stoa/paasali.csv
+++ b/programme/models/paikkala_data/kulttuurikeskus-stoa/paasali.csv
@@ -1,0 +1,11 @@
+zone,row,start,end
+Pääsali, 0 - numeroimattomat paikat,1,25
+Pääsali, 1 - numeroimattomat paikat,1,25
+Pääsali, 2 - numeroimattomat paikat,1,25
+Pääsali, 3 - numeroimattomat paikat,1,25
+Pääsali, 4 - numeroimattomat paikat,1,25
+Pääsali, 5 - numeroimattomat paikat,1,25
+Pääsali, 6 - numeroimattomat paikat,1,25
+Pääsali, 7 - numeroimattomat paikat,1,25
+Pääsali, 8 - numeroimattomat paikat,1,16
+Pääsali, 9 - numeroimattomat paikat,1,15

--- a/programme/models/paikkala_data/kulttuurikeskus-stoa/paasali.csv
+++ b/programme/models/paikkala_data/kulttuurikeskus-stoa/paasali.csv
@@ -1,11 +1,11 @@
 zone,row,start,end
-Pääsali, 0 - numeroimattomat paikat,1,25
-Pääsali, 1 - numeroimattomat paikat,1,25
-Pääsali, 2 - numeroimattomat paikat,1,25
-Pääsali, 3 - numeroimattomat paikat,1,25
-Pääsali, 4 - numeroimattomat paikat,1,25
-Pääsali, 5 - numeroimattomat paikat,1,25
-Pääsali, 6 - numeroimattomat paikat,1,25
-Pääsali, 7 - numeroimattomat paikat,1,25
-Pääsali, 8 - numeroimattomat paikat,1,16
-Pääsali, 9 - numeroimattomat paikat,1,15
+Pääsali,0 - numeroimattomat paikat,1,25
+Pääsali,1 - numeroimattomat paikat,1,25
+Pääsali,2 - numeroimattomat paikat,1,25
+Pääsali,3 - numeroimattomat paikat,1,25
+Pääsali,4 - numeroimattomat paikat,1,25
+Pääsali,5 - numeroimattomat paikat,1,25
+Pääsali,6 - numeroimattomat paikat,1,25
+Pääsali,7 - numeroimattomat paikat,1,25
+Pääsali,8 - numeroimattomat paikat,1,16
+Pääsali,9 - numeroimattomat paikat,1,15


### PR DESCRIPTION
Added seat map of Kulttuurikeskus Stoa Teatterisali which is the main hall in Shumicon.

This layout can trigger #313 but should be unlikely when people only reserve a few places.