### PR TITLE
Add some reformatting commits into .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# chore: switch from Black to Ruff, run autofix
+bca30f9dcdb9f54d3087388958a7f547406abde7
+# update deps (also does a reformat)
+70805688b1baf08d7276acbd8dfc77646c377bc9


### PR DESCRIPTION
[`.git-blame-ignore-revs` is the standard name supported by GitHub](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/).

Locally, you can enable this in your Kompassi working copy with

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```