### PR TITLE
Forbid asserts in (new) runtime code

### DIFF
--- a/backend/access/models/privilege.py
+++ b/backend/access/models/privilege.py
@@ -61,7 +61,8 @@ class Privilege(models.Model):
 
     @classmethod
     def get_potential_privileges(cls, person, **extra_criteria):
-        assert person.user is not None
+        if not person.user:
+            raise ValueError("person.user must be set")
         return (
             cls.objects.filter(group_privileges__group__in=person.user.groups.all(), **extra_criteria)
             .exclude(granted_privileges__person=person)

--- a/backend/api_v2/urls.py
+++ b/backend/api_v2/urls.py
@@ -6,7 +6,8 @@ from oauth2_provider.views.base import RevokeTokenView, TokenView
 
 from .views import CustomAuthorizationView, EventResource, MyselfResource
 
-assert "oauth2_provider" in settings.INSTALLED_APPS, "api_v2 requires oauth2_provider"
+if "oauth2_provider" not in settings.INSTALLED_APPS:
+    raise AssertionError("api_v2 requires oauth2_provider")
 
 
 urlpatterns = [

--- a/backend/badges/models/badge.py
+++ b/backend/badges/models/badge.py
@@ -202,7 +202,8 @@ class Badge(models.Model, CsvExportMixin):
 
         from badges.utils import default_badge_factory
 
-        assert person is not None
+        if not person:
+            raise AssertionError("person is not set")
 
         with transaction.atomic():
             try:
@@ -339,7 +340,8 @@ class Badge(models.Model, CsvExportMixin):
         because a batch that is already created but not yet printed may have been downloaded as Excel
         already. A Batch should never change after being created.
         """
-        assert not self.is_revoked
+        if self.is_revoked:
+            raise AssertionError("Already revoked")
 
         if self.is_printed_separately or self.batch:
             self.is_revoked = True
@@ -351,7 +353,8 @@ class Badge(models.Model, CsvExportMixin):
             return None
 
     def unrevoke(self):
-        assert self.is_revoked
+        if not self.is_revoked:
+            raise AssertionError("Not revoked")
         self.is_revoked = False
         self.revoked_by = None
         self.save()

--- a/backend/badges/models/batch.py
+++ b/backend/badges/models/batch.py
@@ -48,7 +48,8 @@ class Batch(models.Model):
         from .badge import Badge
 
         if personnel_class is not None:
-            assert personnel_class.event == event
+            if personnel_class.event != event:
+                raise AssertionError("personnel_class in wrong event")
             badges = Badge.objects.filter(personnel_class=personnel_class)
         else:
             badges = Badge.objects.filter(personnel_class__event=event)

--- a/backend/core/helpers.py
+++ b/backend/core/helpers.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 
 from .models import Event, Organization, Person
@@ -84,12 +85,14 @@ def unperson_page_wizard(*pages):
 
     Directs any User without Person through a series of pages before letting them perform this view.
     """
-    assert len(pages) >= 1
+    if len(pages) < 1:
+        raise ValueError("Must have at least one page")
 
     def outer(view_func):
         @wraps(view_func)
         def inner(request, *args, **kwargs):
-            assert request.user.is_authenticated
+            if not request.user.is_authenticated:
+                raise PermissionDenied("User not authenticated")
 
             try:
                 _person = request.user.person

--- a/backend/core/management/commands/async_cmd.py
+++ b/backend/core/management/commands/async_cmd.py
@@ -9,7 +9,8 @@ class Command(BaseCommand):
         parser.add_argument("async_cmd_args", nargs="+", type=str)
 
     def handle(self, *args, **options):
-        assert "background_tasks" in settings.INSTALLED_APPS
+        if "background_tasks" not in settings.INSTALLED_APPS:
+            raise AssertionError('"background_tasks" not installed')
 
         from core.tasks import run_admin_command
 

--- a/backend/core/merge_people.py
+++ b/backend/core/merge_people.py
@@ -116,7 +116,8 @@ def merge(mergee, into):
     Updates all references to `mergee` to point to `into` and deletes `mergee`.
     """
     ModelClass = mergee._meta.model
-    assert into._meta.model is ModelClass, "thou shalt not merge instances of different models"
+    if into._meta.model is not ModelClass:
+        raise AssertionError("thou shalt not merge instances of different models")
 
     for RelatedModel, field in get_reference_fields(ModelClass):
         if field.many_to_many:

--- a/backend/core/models/group_management_mixin.py
+++ b/backend/core/models/group_management_mixin.py
@@ -22,7 +22,10 @@ class GroupManagementMixin:
     def make_group_name(cls, host, suffix):
         # to avoid cases where someone calls .get_or_create_groups(foo, 'admins')
         # and would otherwise get groups a, d, m, i, n, s...
-        assert isinstance(suffix, str) and len(suffix) > 1
+        if not isinstance(suffix, str):
+            raise TypeError("suffix must be a string")
+        if len(suffix) <= 1:
+            raise ValueError(f"suffix {suffix!r} should be longer than a single character")
 
         from django.contrib.contenttypes.models import ContentType
 

--- a/backend/core/models/one_time_code.py
+++ b/backend/core/models/one_time_code.py
@@ -32,7 +32,8 @@ class OneTimeCodeMixin:
         return self.code
 
     def revoke(self):
-        assert self.state == "valid"
+        if self.state != "valid":
+            raise ValueError("Must be valid to revoke")
         self.state = "revoked"
         self.used_at = timezone.now()
         self.save()
@@ -69,7 +70,8 @@ class OneTimeCodeMixin:
             EmailMessage(**opts).send(fail_silently=True)
 
     def mark_used(self):
-        assert self.state == "valid"
+        if self.state != "valid":
+            raise ValueError("Must be valid to mark used")
 
         self.used_at = timezone.now()
         self.state = "used"

--- a/backend/core/models/person.py
+++ b/backend/core/models/person.py
@@ -484,7 +484,8 @@ class Person(models.Model):
         )
 
     def ensure_basic_groups(self):
-        assert self.user
+        if not self.user:
+            raise AssertionError("self.user")
         for group_name in settings.KOMPASSI_NEW_USER_GROUPS:
             self.user.groups.add(Group.objects.get(name=group_name))
 

--- a/backend/core/page_wizard.py
+++ b/backend/core/page_wizard.py
@@ -4,7 +4,8 @@ from .utils import get_next, url
 
 
 def page_wizard_init(request, pages):
-    assert all(len(page) in [2, 3] for page in pages)
+    if not all(len(page) in (2, 3) for page in pages):
+        raise AssertionError("Some pages have wrong lengths")
 
     steps = []
     all_related = set()

--- a/backend/core/utils/model_utils.py
+++ b/backend/core/utils/model_utils.py
@@ -37,7 +37,8 @@ def get_slugifier(sep: str = "-"):
     'foo_bar'
     """
 
-    assert len(sep) == 1, "Separator must be a single character"
+    if len(sep) != 1:
+        raise AssertionError("Separator must be a single character")
 
     char_map = {
         " ": sep,

--- a/backend/core/utils/password_utils.py
+++ b/backend/core/utils/password_utils.py
@@ -101,7 +101,8 @@ def get_hibp_page(hash_prefix):
     """
     # TODO Use a cache decorator
 
-    assert len(hash_prefix) == HIBP_PREFIX_LENGTH, "Hash prefix length mismatch"
+    if len(hash_prefix) != HIBP_PREFIX_LENGTH:
+        raise AssertionError("Hash prefix length mismatch")
 
     try:
         int(hash_prefix, 16)

--- a/backend/core/views/core_fobba_export_view.py
+++ b/backend/core/views/core_fobba_export_view.py
@@ -69,7 +69,8 @@ def core_fobba_export_view(request, event_slug, format="xlsx"):
         cancellation_time__isnull=True,
     ):
         customer = order.customer
-        assert customer
+        if not customer:
+            raise AssertionError("customer missing")
 
         id_fields = (
             customer.last_name,

--- a/backend/enrollment/models/enrollment.py
+++ b/backend/enrollment/models/enrollment.py
@@ -127,7 +127,8 @@ class Enrollment(models.Model):
     updated_at = models.DateTimeField(auto_now=True, verbose_name=_("updated at"))
 
     def cancel(self):
-        assert self.state in ["NEW", "ACCEPTED"]
+        if self.state not in ("NEW", "ACCEPTED"):
+            raise AssertionError(f"Can't cancel enrollment in state {self.state}")
         self.state = "CANCELLED"
         self.save()
 

--- a/backend/event_log/channels/callback.py
+++ b/backend/event_log/channels/callback.py
@@ -1,4 +1,5 @@
 def send_update_for_entry(subscription, entry):
-    assert subscription.channel == "callback"
+    if subscription.channel != "callback":
+        raise AssertionError("subscription.channel is not callback")
 
     subscription.callback(subscription, entry)

--- a/backend/event_log/channels/email.py
+++ b/backend/event_log/channels/email.py
@@ -3,7 +3,8 @@ from django.core.mail import EmailMessage
 
 
 def send_update_for_entry(subscription, entry):
-    assert subscription.channel == "email"
+    if subscription.channel != "email":
+        raise AssertionError("subscription.channel must be email")
 
     subject = entry.email_subject
     body = entry.email_body

--- a/backend/event_log/models/subscription.py
+++ b/backend/event_log/models/subscription.py
@@ -60,7 +60,8 @@ class Subscription(models.Model):
     callback = code_property("callback_code")
 
     def send_update_for_entry(self, entry):
-        assert self.active
+        if not self.active:
+            raise ValueError("Subscription must be active")
 
         if "background_tasks" in settings.INSTALLED_APPS:
             from ..tasks import subscription_send_update_for_entry

--- a/backend/events/desucon2024/forms.py
+++ b/backend/events/desucon2024/forms.py
@@ -51,7 +51,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 
@@ -145,7 +146,8 @@ class ProgrammeSignupExtraForm(forms.ModelForm, AlternativeFormMixin):
 
 class SpecialistSignupForm(SignupForm, AlternativeFormMixin):
     def get_job_categories_query(self, event, admin=False):
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         return Q(event__slug="desucon2024", public=False) & ~Q(slug="vastaava")
 

--- a/backend/events/frostbite2024/forms.py
+++ b/backend/events/frostbite2024/forms.py
@@ -51,7 +51,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 
@@ -145,7 +146,8 @@ class ProgrammeSignupExtraForm(forms.ModelForm, AlternativeFormMixin):
 
 class SpecialistSignupForm(SignupForm, AlternativeFormMixin):
     def get_job_categories_query(self, event, admin=False):
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         return Q(event__slug="frostbite2024", public=False) & ~Q(slug="vastaava")
 

--- a/backend/events/hitpoint2024/forms.py
+++ b/backend/events/hitpoint2024/forms.py
@@ -78,7 +78,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 

--- a/backend/events/kotaeexpo2024/forms.py
+++ b/backend/events/kotaeexpo2024/forms.py
@@ -69,7 +69,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 
@@ -142,7 +143,8 @@ class OrganizerSignupExtraForm(forms.ModelForm, AlternativeFormMixin):
 
 class SpecialistSignupForm(SignupForm, AlternativeFormMixin):
     def get_job_categories_query(self, event, admin=False):
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         return Q(event__slug="kotaeexpo2024", public=False) & ~Q(slug="vastaava")
 

--- a/backend/events/kuplii2024/forms.py
+++ b/backend/events/kuplii2024/forms.py
@@ -46,7 +46,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 

--- a/backend/events/ropecon2020vd/forms.py
+++ b/backend/events/ropecon2020vd/forms.py
@@ -893,7 +893,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 

--- a/backend/events/ropecon2024/forms.py
+++ b/backend/events/ropecon2024/forms.py
@@ -1198,7 +1198,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 
@@ -1266,7 +1267,8 @@ class OrganizerSignupExtraForm(forms.ModelForm, AlternativeFormMixin):
 
 class SpecialistSignupForm(SignupForm, AlternativeFormMixin):
     def get_job_categories_query(self, event, admin=False):
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         return Q(event__slug="ropecon2024", name__in=["Boffaus", "Teehuone"])
 

--- a/backend/events/tracon2024/forms.py
+++ b/backend/events/tracon2024/forms.py
@@ -83,7 +83,8 @@ class OrganizerSignupForm(forms.ModelForm, AlternativeFormMixin):
         kwargs.pop("event")
         admin = kwargs.pop("admin")
 
-        assert not admin
+        if admin:
+            raise AssertionError("must not be admin")
 
         super().__init__(*args, **kwargs)
 

--- a/backend/events/tracon2024/proxies.py
+++ b/backend/events/tracon2024/proxies.py
@@ -62,7 +62,7 @@ class SignupExtraAfterpartyProxy(SignupExtra, CsvExportMixin):
 
     @classmethod
     def get_csv_fields(cls, event):
-        assert event.slug == "tracon2024"
+        assert event.slug == "tracon2024"  # noqa: S101
         from core.models import Person
 
         return [

--- a/backend/events/tracon2024/views.py
+++ b/backend/events/tracon2024/views.py
@@ -13,7 +13,7 @@ from .proxies import SignupExtraAfterpartyProxy
 
 @default_cbac_required
 def tracon2024_afterparty_participants_view(request, event_slug):
-    assert event_slug == "tracon2024"
+    assert event_slug == "tracon2024"  # noqa: S101
     event = Event.objects.get(slug=event_slug)
 
     participants = SignupExtraAfterpartyProxy.objects.filter(afterparty_participation=True)
@@ -37,7 +37,7 @@ def tracon2024_afterparty_participants_view(request, event_slug):
 
 @default_cbac_required
 def tracon2024_afterparty_summary_view(request, event_slug):
-    assert event_slug == "tracon2024"
+    assert event_slug == "tracon2024"  # noqa: S101
     event = Event.objects.get(slug=event_slug)
 
     poisons = Poison.objects.all().annotate(

--- a/backend/forms/graphql/meta.py
+++ b/backend/forms/graphql/meta.py
@@ -1,5 +1,6 @@
 import graphene
 from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
 
 from access.cbac import graphql_check_access
 from core.utils import get_objects_within_period, normalize_whitespace
@@ -44,7 +45,8 @@ class FormsProfileMetaType(graphene.ObjectType):
         """
         Returns all responses submitted by the current user.
         """
-        assert info.context.user == meta.person.user
+        if info.context.user != meta.person.user:
+            raise SuspiciousOperation("User mismatch")
         return Response.objects.filter(created_by=meta.person.user).order_by("-created_at")
 
     responses = graphene.NonNull(
@@ -59,7 +61,8 @@ class FormsProfileMetaType(graphene.ObjectType):
         """
         Returns a single response submitted by the current user.
         """
-        assert info.context.user == meta.person.user
+        if info.context.user != meta.person.user:
+            raise SuspiciousOperation("User mismatch")
         return Response.objects.get(created_by=meta.person.user, id=id)
 
     response = graphene.Field(

--- a/backend/forms/models/form.py
+++ b/backend/forms/models/form.py
@@ -69,7 +69,8 @@ class Form(models.Model):
         field = deepcopy(field)
 
         if choices_from := field.get("choicesFrom"):
-            assert len(choices_from) == 1, "choicesFrom must have exactly one key: value pair"
+            if len(choices_from) != 1:
+                raise AssertionError("choicesFrom must have exactly one key: value pair")
             ((source_type, source),) = choices_from.items()
             if source_type == "dimension":
                 dimension = Dimension.objects.get(event=self.event, slug=source)

--- a/backend/intra/forms.py
+++ b/backend/intra/forms.py
@@ -136,7 +136,8 @@ class PrivilegesForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        assert "initial" not in kwargs
+        if "initial" in kwargs:
+            raise AssertionError('"initial" must not be passed to PrivilegesForm')
 
         self.event = kwargs.pop("event")
         self.user = kwargs.pop("user")

--- a/backend/labour/models/job_category.py
+++ b/backend/labour/models/job_category.py
@@ -181,9 +181,8 @@ class JobCategory(models.Model):
         return super().save(*args, **kwargs)
 
     def as_dict(self, include_jobs=False, include_requirements=False, include_people=False, include_shifts=False):
-        assert not (
-            include_shifts and not include_jobs
-        ), "If include_shifts is specified, must specify also include_jobs"
+        if include_shifts and not include_jobs:
+            raise AssertionError("If include_shifts is specified, must specify also include_jobs")
 
         doc = pick_attrs(
             self,

--- a/backend/labour/models/signup.py
+++ b/backend/labour/models/signup.py
@@ -416,7 +416,8 @@ class Signup(CsvExportMixin, SignupMixin, models.Model):
     @classmethod
     def get_state_query_params(cls, state):
         flag_values = STATE_FLAGS_BY_NAME[state]
-        assert len(STATE_TIME_FIELDS) == len(flag_values)
+        if len(STATE_TIME_FIELDS) != len(flag_values):
+            raise ValueError("STATE_TIME_FIELDS and STATE_FLAGS_BY_NAME are out of sync")
 
         query_params = []
 
@@ -707,7 +708,8 @@ class Signup(CsvExportMixin, SignupMixin, models.Model):
         return self.state == "confirmation"
 
     def confirm(self):
-        assert self.state == "confirmation"
+        if self.state != "confirmation":
+            raise ValueError(f"Must be in state 'confirmation' to confirm, not {self.state}")
 
         self.state = "accepted"
         self.save()

--- a/backend/labour/models/signup_extras.py
+++ b/backend/labour/models/signup_extras.py
@@ -108,7 +108,8 @@ class SignupExtraBase(SignupExtraMixin, models.Model):
         return result
 
     def as_dict(self, format: Literal["discord"]):
-        assert format == "discord", "not implemented"
+        if format != "discord":
+            raise AssertionError("not implemented")
         return dict(
             handle=self.person.discord_handle,
             roles=self.discord_roles,

--- a/backend/labour/proxies/signup/onboarding.py
+++ b/backend/labour/proxies/signup/onboarding.py
@@ -24,7 +24,8 @@ class SignupOnboardingProxy(Signup):
         proxy = True
 
     def mark_arrived(self, is_arrived):
-        assert self.is_active, "Will not mark an inactive Signup as arrived"
+        if not self.is_active:
+            raise AssertionError("Will not mark an inactive Signup as arrived")
 
         if is_arrived:
             self.state = STATE_ARRIVED

--- a/backend/labour/views/view_helpers.py
+++ b/backend/labour/views/view_helpers.py
@@ -2,7 +2,9 @@ from core.utils import initialize_form
 
 
 def initialize_signup_forms(request, event, signup, admin=False, SignupFormClass=None, SignupExtraFormClass=None):
-    assert all([SignupFormClass, SignupExtraFormClass]) or not any([SignupFormClass, SignupExtraFormClass])
+    assert (  # noqa: S101
+        all([SignupFormClass, SignupExtraFormClass]) or not any([SignupFormClass, SignupExtraFormClass])
+    )
 
     signup_extra = signup.signup_extra
 

--- a/backend/listings/models.py
+++ b/backend/listings/models.py
@@ -85,7 +85,8 @@ class ExternalEvent(models.Model):
         return " ".join(headline_parts)
 
     def as_dict(self, format="listing"):
-        assert format == "listing"
+        if format != "listing":
+            raise ValueError("Only format=listing is supported")
 
         return pick_attrs(
             self,

--- a/backend/mailings/models.py
+++ b/backend/mailings/models.py
@@ -170,14 +170,17 @@ class Message(models.Model):
                 person_message.actually_send()
 
     def expire(self):
-        assert self.expired_at is None, "re-expiring an expired message does not make sense"
-        assert self.sent_at is not None, "expiring an unsent message does not make sense"
+        if self.expired_at is not None:
+            raise AssertionError("re-expiring an expired message does not make sense")
+        if self.sent_at is None:
+            raise AssertionError("expiring an unsent message does not make sense")
 
         self.expired_at = datetime.now()
         self.save()
 
     def unexpire(self):
-        assert self.expired_at is not None, "cannot un-expire a non-expired message"
+        if not self.expired_at is not None:
+            raise AssertionError("cannot un-expire a non-expired message")
 
         self.expired_at = None
         self.save()

--- a/backend/membership/models.py
+++ b/backend/membership/models.py
@@ -303,7 +303,8 @@ class Term(models.Model):
         return super().save(*args, **kwargs)
 
     def get_reference_number_for_member(self, member):
-        assert self.reference_number_template
+        if not self.reference_number_template:
+            raise ValueError("Reference number template missing")
         return append_reference_number_checksum(self.reference_number_template.format(member.id))
 
     @property
@@ -382,7 +383,8 @@ class MembershipFeePayment(models.Model):
         )
 
     def confirm_payment(self, payment_date=None, payment_method="checkout"):
-        assert not self.is_paid
+        if self.is_paid:
+            raise ValueError("Already paid!")
 
         if payment_date is None:
             payment_date = date.today()

--- a/backend/programme/management/commands/paikkala_simulate.py
+++ b/backend/programme/management/commands/paikkala_simulate.py
@@ -88,8 +88,10 @@ class Command(BaseCommand):
                 print()
                 print(tabulate(results, headers=("Zone", "Reserved", "Remaining", "Capacity")))
 
-                assert total_reserved == total_capacity, "All seats must be reserved"
-                assert total_remaining == 0, "No seats must be remaining"
+                if total_reserved != total_capacity:
+                    raise AssertionError("All seats must be reserved")
+                if total_remaining != 0:
+                    raise AssertionError("No seats must be remaining")
 
                 raise NotReally("It was only a dream :)")
         except NotReally:

--- a/backend/programme/management/commands/repaikkalize.py
+++ b/backend/programme/management/commands/repaikkalize.py
@@ -72,8 +72,10 @@ class Command(BaseCommand):
                 print(pzones)
 
                 # I am paranoid about runaway cascades
-                assert ps.distinct().count() == num_ps
-                assert rooms.distinct().count() == num_rooms
+                if ps.distinct().count() != num_ps:
+                    raise AssertionError("ps.distinct().count() == num_ps")
+                if rooms.distinct().count() != num_rooms:
+                    raise AssertionError("rooms.distinct().count() == num_rooms")
 
                 if not opts["really"]:
                     raise NotReally("It was all a bad dream :)")

--- a/backend/programme/models/programme.py
+++ b/backend/programme/models/programme.py
@@ -1747,7 +1747,8 @@ class Programme(models.Model, CsvExportMixin):
         from .programme_role import ProgrammeRole
 
         for person in self.organizers.all():
-            assert person.user
+            if not person.user:
+                raise ValueError(f"{person=} has no associated user")
 
             groups_to_add = []
             groups_to_remove = []
@@ -1885,7 +1886,7 @@ class Programme(models.Model, CsvExportMixin):
 
     @property
     def host_cannot_edit_explanation(self):
-        assert not self.host_can_edit
+        assert not self.host_can_edit  # noqa: S101
 
         if self.state == "cancelled":
             return _("You have cancelled this programme.")
@@ -1926,7 +1927,8 @@ class Programme(models.Model, CsvExportMixin):
         if self.paikkala_program:
             return self.paikkala_program
 
-        assert self.can_paikkalize
+        if not self.can_paikkalize:
+            raise AssertionError("self.can_paikkalize")
 
         from django.template.defaultfilters import truncatechars
         from paikkala.models import Program as PaikkalaProgram

--- a/backend/programme/views/admin_mail_editor_view.py
+++ b/backend/programme/views/admin_mail_editor_view.py
@@ -28,7 +28,8 @@ def admin_mail_editor_view(request, vars, event, message_id=None):
         action = request.POST.get("action")
 
         if action == "delete":
-            assert message
+            if not message:
+                raise AssertionError("message must be set")
             if message.is_sent:
                 messages.error(request, "Lähetettyä viestiä ei voi poistaa.")
             else:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ extend-select = [
     "RUF100",  # unused noqa
     "SIM",
     "UP",
+    "S101",  # asserts
 ]
 extend-ignore = [
     "C408",  # unnecessary dict call (these are likely stylistic)
@@ -47,4 +48,14 @@ extend-ignore = [
 ]
 "**/test*.py" = [
     "PLR2004",  # magic values are ok in tests
+    "S101",  # asserts are ok in tests
+]
+"events/*201*/*.py" = [
+    "S101",  # asserts are ok in legacy events
+]
+"events/*202[0123]/*.py" = [
+    "S101",  # asserts are ok in legacy events
+]
+"**/management/**.py" = [
+    "S101",  # asserts are ok in one-off management commands
 ]

--- a/backend/tickets/views/tickets_v1_5_views.py
+++ b/backend/tickets/views/tickets_v1_5_views.py
@@ -108,7 +108,8 @@ def tickets_confirmed_view(request, event, order):
     If that order is not paid, this view will present the user a message saying so, and
     a button to complete the payment.
     """
-    assert order.is_confirmed
+    if not order.is_confirmed:
+        raise ValueError("order must be confirmed")
 
     vars = dict(
         event=event,


### PR DESCRIPTION
For the most part, one would want to avoid `assert`s in runtime code.

A bit of `ast-grep` and some elbow grease... I hope I got the simplification of all these expressions right.

```
ast-grep run --pattern 'assert $A, $B' --rewrite 'if not $A: raise AssertionError($B)' -l python -i $(git ls-files '*.py' | grep -v test)
ast-grep run --pattern 'assert $A' --rewrite 'if not $A: raise AssertionError(\'$A\')' -l python -i $(git ls-files '*.py' | grep -v test)
```
