### PR TITLE
Expense claim form for Tracon

### DIFF
--- a/backend/events/tracon2024/forms/expense-claim-dimensions.yml
+++ b/backend/events/tracon2024/forms/expense-claim-dimensions.yml
@@ -1,0 +1,53 @@
+- slug: type
+  title:
+    fi: Maksun tyyppi
+    en: Payment type
+  is_key_dimension: true
+  choices:
+    - slug: bank-transfer
+      # TODO(#391): implement form-visible default values
+      # is_default: true
+      title:
+        fi: Tilisiirto
+        en: Bank transfer
+    - slug: invoice
+      title:
+        fi: Lasku
+        en: Invoice
+    - slug: card-payment
+      title:
+        fi: Korttimaksu
+        en: Card payment
+
+- slug: status
+  title:
+    fi: Maksun tila
+    en: Payment status
+  is_key_dimension: true
+  choices:
+    - slug: new
+      color: blue
+      is_initial: true
+      title:
+        fi: Uusi
+        en: New
+    - slug: accepted
+      color: green
+      title:
+        fi: Hyväksytty
+        en: Accepted
+    - slug: paid
+      color: teal
+      title:
+        fi: Maksettu
+        en: Paid
+    - slug: info-requested
+      color: yellow
+      title:
+        fi: Lisätietoja pyydetty
+        en: Further details requested
+    - slug: rejected
+      color: red
+      title:
+        fi: Hylätty
+        en: Rejected

--- a/backend/events/tracon2024/forms/expense-claim-fi.yml
+++ b/backend/events/tracon2024/forms/expense-claim-fi.yml
@@ -1,0 +1,85 @@
+title: Hae kulukorvausta
+layout: vertical
+description: |
+  Tällä lomakkeella voit hakea kulukorvausta <strong>vuoden 2024 Traconiin liittyvistä kuluista</strong>,
+  lähettää Tracon ry:lle laskun tai toimittaa Tracon ry:n pankkikortilla maksetun kulun kuitin.
+  Täytä lomake huolellisesti ja liitä mukaan kaikki pyydetyt liitteet.
+
+  Jos haet kulukorvausta <strong>vuoden 2024 Tracon Hitpoint -tapahtumaan</strong> liittyvistä kuluista,
+  käytä <a href="/events/hitpoint2024/surveys/expense-claim">Hitpointin kulukorvauslomaketta</a>.
+
+  Jos haet kulukorvausta <strong>kulusta, joka ei liity suoraan kumpaankaan tapahtumaan</strong>,
+  käytä <a href="/events/tracon2024/surveys/expense-claim-traconry-temp">yleistä kulukorvauslomaketta</a>.
+
+  Jos sinulla on kysyttävää kulukorvauksista, ota yhteyttä Tracon ry:n rahastonhoitajaan sähköpostitse
+  osoitteella <em>rahat ät tracon piste fi</em> tai Slackissa <em>@Aketzu</em>.
+fields:
+  - slug: type
+    type: SingleSelect
+    title: Kulukorvauksen tyyppi
+    helpText: |
+      <strong>Tilisiirto:</strong> Olet maksanut kulun itse ja haet korvausta tilisiirtona.<br/>
+      <strong>Lasku:</strong> Laskuttaja on lähettänyt Tracon ry:lle laskun, joka maksetaan suoraan laskuttajalle.<br/>
+      <strong>Korttimaksu:</strong> Olet maksanut kulun Tracon ry:n pankkikortilla. Kirjoita saajan tilinumero -kenttään "-" (viiva).
+    required: true
+    choicesFrom:
+      dimension: type
+
+  - slug: title
+    type: SingleLineText
+    title: Otsikko
+    required: true
+    helpText: Kerro <strong>lyhyesti</strong>, mistä kulusta haet korvausta tai mitä lasku koskee.
+
+  - slug: description
+    type: MultiLineText
+    title: Kuvaus
+    helpText: |
+      Jos otsikko ei kerro kaikkea olennaista, voit antaa tässä lisätietoja.
+
+  - slug: amount
+    type: SingleLineText
+    title: Summa
+    required: true
+    helpText: |
+      Kuinka paljon haet korvausta tai mikä on laskun summa? Kirjoita summa euroina.
+
+  - slug: recipient
+    type: SingleLineText
+    title: Saaja
+    helpText: |
+      Kenen tilille korvaus maksetaan? Kirjoita tähän etu- ja sukunimi tai yrityksen nimi.
+      Jos korvaus maksetaan omalle tilillesi, voit jättää tämän kentän tyhjäksi.
+
+  - slug: recipient_iban
+    type: SingleLineText
+    title: Saajan tilinumero
+    required: true
+    helpText: |
+      Mille tilille korvaus maksetaan? Kirjoita IBAN-tilinumero muodossa FI12 3456 7890 1234 56.
+
+  - slug: recipient_bic
+    type: SingleLineText
+    title: Saajan pankin SWIFT/BIC-koodi
+    helpText: |
+      Minkä pankin tilille korvaus maksetaan? Kirjoita pankin SWIFT/BIC-koodi (esim. HOLVFIHH tai NDEAFIHH).
+      Jos saajan tili on suomalaisessa pankissa eli tilinumero alkaa FI, voit jättää tämän kentän tyhjäksi.
+
+  - slug: reference_number
+    type: SingleLineText
+    title: Viitenumero
+    helpText: |
+      Jos kulukorvaukseen liittyy lasku jolla on viitenumero, kirjoita se tähän.
+      Muutoin voit jättää tämän kentän tyhjäksi.
+
+  - slug: attachments
+    type: FileUpload
+    title: Tositteet
+    required: true
+    helpText: |
+      Liitä mukaan kaikki kulukorvauksen kannalta tarpeelliset tositteet.
+      Tositteista tulee käydä ilmi kulun päivämäärä, summa, ALV-kanta ja maksun saaja.
+      Muussa valuutassa kuin euroissa tehdyistä maksuista tulee käydä ilmi myös valuuttakurssi tai
+      summa alkuperäisessä valuutassa.
+      Jos sinulla ei ole tositetta, kirjoita vapaamuotoinen selvitys kulusta ja
+      siitä, miksi tositetta ei ole saatavilla, ja allekirjoita se.

--- a/backend/forms/graphql/survey.py
+++ b/backend/forms/graphql/survey.py
@@ -165,7 +165,7 @@ class SurveyType(LimitedSurveyType):
 
     @staticmethod
     def resolve_dimensions(survey: Survey, info, key_dimensions_only: bool = False):
-        qs = survey.dimensions.all()
+        qs = survey.dimensions.all().order_by("order", "slug")
 
         if key_dimensions_only:
             qs = qs.filter(is_key_dimension=True)

--- a/backend/forms/models/dimension.py
+++ b/backend/forms/models/dimension.py
@@ -125,11 +125,10 @@ class DimensionDTO(pydantic.BaseModel):
     slug: str
     title: dict[str, str]
     choices: list[DimensionValueDTO]
-    order: int = 0
     is_key_dimension: bool = False
     is_multi_value: bool = False
 
-    def save(self, survey: Survey):
+    def save(self, survey: Survey, order: int = 0):
         # TODO change to get_or_create when form editor is implemented
         # so that these can be loaded once but user changes are not overwritten
         dimension, _created = Dimension.objects.update_or_create(
@@ -137,9 +136,9 @@ class DimensionDTO(pydantic.BaseModel):
             slug=self.slug,
             defaults=dict(
                 title=self.title,
-                order=self.order,
                 is_key_dimension=self.is_key_dimension,
                 is_multi_value=self.is_multi_value,
+                order=order,
             ),
         )
 
@@ -151,6 +150,13 @@ class DimensionDTO(pydantic.BaseModel):
 
         for choice in self.choices:
             choice.save(dimension)
+
+    @classmethod
+    def save_many(cls, survey: Survey, dimensions: list[DimensionDTO]):
+        order = 0
+        for dimension in dimensions:
+            order += 10
+            dimension.save(survey, order)
 
 
 class ResponseDimensionValue(models.Model):

--- a/frontend/src/app/[locale]/events/[eventSlug]/surveys/[surveySlug]/responses/page.tsx
+++ b/frontend/src/app/[locale]/events/[eventSlug]/surveys/[surveySlug]/responses/page.tsx
@@ -15,7 +15,7 @@ import {
   getDimensionValueTitle,
 } from "@/components/dimensions/helpers";
 import { validateFields } from "@/components/SchemaForm/models";
-import { extractBasenameFromPresignedUrl } from "@/components/SchemaForm/UploadedFileCards";
+import UploadedFileLink from "@/components/SchemaForm/UploadedFileLink";
 import SignInRequired from "@/components/SignInRequired";
 import ViewContainer from "@/components/ViewContainer";
 import ViewHeading from "@/components/ViewHeading";
@@ -191,12 +191,9 @@ export default async function FormResponsesPage({
           // value is a list of presigned S3 URLs
           const urls: string[] = value ?? [];
           return urls.map((url, idx) => {
-            const basename = extractBasenameFromPresignedUrl(url);
             return (
               <Fragment key={idx}>
-                <a href={url} target="_blank" rel="noreferrer">
-                  {basename}
-                </a>
+                <UploadedFileLink url={url} />
                 {idx !== urls.length - 1 && ", "}
               </Fragment>
             );

--- a/frontend/src/components/SchemaForm/SchemaFormInput.tsx
+++ b/frontend/src/components/SchemaForm/SchemaFormInput.tsx
@@ -1,7 +1,5 @@
 import type { Field } from "./models";
-import UploadedFileCards, {
-  extractBasenameFromPresignedUrl,
-} from "./UploadedFileCards";
+import UploadedFileCards from "./UploadedFileCards";
 import type { Translations } from "@/translations/en";
 
 interface SchemaFormInputProps {

--- a/frontend/src/components/SchemaForm/UploadedFileCards.tsx
+++ b/frontend/src/components/SchemaForm/UploadedFileCards.tsx
@@ -1,9 +1,5 @@
+import UploadedFileLink from "./UploadedFileLink";
 import type { Translations } from "@/translations/en";
-
-export function extractBasenameFromPresignedUrl(url: string) {
-  const urlObj = new URL(url);
-  return urlObj.pathname.split("/").pop();
-}
 
 interface Props {
   urls?: string[];
@@ -24,18 +20,13 @@ export default function UploadedFileCards({ urls, messages }: Props) {
   // value is a list of presigned S3 URLs
   return (
     <>
-      {urls.map((url, idx) => {
-        const basename = extractBasenameFromPresignedUrl(url);
-        return (
-          <div key={idx} className="card mb-2">
-            <div className="card-body p-2 ps-3 pe-3">
-              <a href={url} target="_blank" rel="noreferrer">
-                {basename}
-              </a>
-            </div>
+      {urls.map((url, idx) => (
+        <div key={idx} className="card mb-2">
+          <div className="card-body p-2 ps-3 pe-3">
+            <UploadedFileLink url={url} />
           </div>
-        );
-      })}
+        </div>
+      ))}
     </>
   );
 }

--- a/frontend/src/components/SchemaForm/UploadedFileLink.tsx
+++ b/frontend/src/components/SchemaForm/UploadedFileLink.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  url: string;
+}
+
+export default function UploadedFileLink({ url }: Props) {
+  const basename = decodeURI(new URL(url).pathname.split("/").pop() || "");
+  return (
+    <a href={url} target="_blank" rel="noreferrer noopener">
+      {basename}
+    </a>
+  );
+}


### PR DESCRIPTION
Closes #347. 

- [x] Merge #390 first, then rebase.

<img width="1552" alt="image" src="https://github.com/con2/kompassi/assets/109397/7ee889a7-b50d-49f0-8257-8eb5b81aab08">

![Screenshot of form (tall)](https://github.com/con2/kompassi/assets/109397/0dfcea6a-bfd6-4ffa-8e84-03c9fad4aeaa)

![Screenshot of single response (tall)](https://github.com/con2/kompassi/assets/109397/dd1a3a29-4380-4ffc-852f-ec8332889fa0)

Further improvement:

- [ ] Add similar forms for Tracon Hitpoint 2024 and Tracon ry non-event-related
- [ ] Money field that accepts two decimals with either dot `.` or comma `,` as the decimal separator

[Blueprint](https://outline.con2.fi/doc/taloushallinto-6UhhJreExZ)
[Slack discussion](https://con2.slack.com/archives/C3ZGNGY48/p1706247844000029)