### PR TITLE
Track membership payments even when fee is optional

### DIFF
--- a/backend/membership/models.py
+++ b/backend/membership/models.py
@@ -221,13 +221,15 @@ class Membership(models.Model, CsvExportMixin):
 
         # TODO entrance fee
 
-        if not term.membership_fee_cents or self.state != "in_effect":
+        if self.state != "in_effect":
             return None
+
+        membership_fee_cents = term.membership_fee_cents or 0
 
         payment = MembershipFeePayment(
             member=self,
             term=term,
-            amount_cents=term.membership_fee_cents,
+            amount_cents=membership_fee_cents,
             payment_method=term.payment_method,
             payment_type="membership_fee",
         )

--- a/backend/membership/templates/membership_admin_member_views/payments_tab.pug
+++ b/backend/membership/templates/membership_admin_member_views/payments_tab.pug
@@ -32,7 +32,7 @@
       else
         if not current_term
           p.text-danger Nykyisen toimikauden tiedot puuttuvat. Syötä tiedot Toimikauden tiedot -näkymässä ennen jäsenmaksujen syöttämistä.
-        if not membership.in_effect
+        if not membership.is_in_effect
           p.text-danger Jäsenyys ei ole tällä hetkellä voimassa. Voit merkitä jäsenmaksun maksetuksi kun jäsenyys on asetettu voimaan.
 
 if membership_fee_payment_form


### PR DESCRIPTION
Wish from Kotae: Kotae ry has an optional membership fee, so membership fee is set to 0 in Kompassi. However, they would like to track who has paid the optional membership fee and what amount they paid.

This is just a nice-to-have, so feel free to reject if you don't like the idea.

Also fixed a tiny display bug.