### PR TITLE
chore(ropecon2024): first stab at program importer

### DIFF
--- a/backend/events/ropecon2024/management/commands/setup_ropecon2024.py
+++ b/backend/events/ropecon2024/management/commands/setup_ropecon2024.py
@@ -31,6 +31,7 @@ class Setup:
         self.setup_programme()
         self.setup_tickets()
         self.setup_badges()
+        self.setup_program_v2()
 
     def setup_core(self):
         from core.models import Event, Organization, Venue
@@ -788,6 +789,24 @@ class Setup:
                     group=team_group,
                 ),
             )
+
+    def setup_program_v2(self):
+        from program_v2.importers.default import DefaultImporter
+        from program_v2.models.dimension import DimensionDTO
+        from program_v2.models.meta import ProgramV2EventMeta
+
+        dimensions = DefaultImporter(self.event).get_dimensions()
+        dimensions = DimensionDTO.save_many(self.event, dimensions)
+        room_dimension = next(d for d in dimensions if d.slug == "room")
+
+        ProgramV2EventMeta.objects.update_or_create(
+            event=self.event,
+            defaults=dict(
+                location_dimension=room_dimension,
+                importer_name="ropecon2024",
+                admin_group=self.event.programme_event_meta.admin_group,
+            ),
+        )
 
 
 class Command(BaseCommand):

--- a/backend/program_v2/importers/ropecon2024.py
+++ b/backend/program_v2/importers/ropecon2024.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from django.utils.timezone import get_current_timezone
+
+from core.models import Event
+from programme.models.programme import Programme
+from programme.models.room import Room
+
+from ..consts import DATE_DIMENSION_TITLE_LOCALIZED, ROOM_DIMENSION_TITLE_LOCALIZED
+from ..models.dimension import DimensionDTO, DimensionValueDTO
+from .default import DefaultImporter
+
+logger = logging.getLogger("kompassi")
+tz = get_current_timezone()
+
+
+@dataclass
+class RopeconImporter(DefaultImporter):
+    event: Event
+    language: str = "fi"
+
+    def get_dimensions(self):
+        return [
+            DimensionDTO(
+                slug="date",
+                title=DATE_DIMENSION_TITLE_LOCALIZED,
+                choices=list(self._get_date_dimension_values()),
+            ),
+            DimensionDTO(
+                slug="type",
+                title=dict(
+                    fi="Ohjelmatyyppi",
+                    en="Program Type",
+                ),
+                choices=[
+                    DimensionValueDTO(
+                        slug=slug,
+                        title=dict(
+                            fi=title_fi,
+                            en=title_en,
+                        ),
+                    )
+                    for slug, title_fi, title_en in [
+                        ("performance", "Esitys", "Performance"),
+                        ("experience", "Kokemus", "Experience"),
+                        ("meetup", "Miitti", "Meetup"),
+                        ("gaming", "Pelaaminen", "Gaming"),
+                        ("talk", "Puheohjelma", "Talk"),
+                        ("activity", "Liikunnallinen", "Activity"),
+                        ("workshop", "Työpaja", "Workshop"),
+                        ("exhibit", "Näyttely", "Exhibit"),
+                    ]
+                ],
+            ),
+            DimensionDTO(
+                slug="room",
+                title=ROOM_DIMENSION_TITLE_LOCALIZED,
+                choices=[
+                    DimensionValueDTO(slug=room.slug, title={self.language: room.name})
+                    for room in Room.objects.filter(event=self.event)
+                ],
+            ),
+        ]
+
+    def get_program_dimension_values(self, programme: Programme) -> dict[str, str | list[str] | None]:
+        return dict(
+            date=self.get_date_dimension_value(programme),
+            type=self.get_type_dimension_value(programme),
+            room=programme.room.slug if programme.room else None,
+        )
+
+    def get_type_dimension_value(self, programme: Programme) -> list[str]:
+        values = set()
+        cat_title_fi = programme.category.title.split("/", 1)[0].strip()
+        prog_title_lower = programme.title.lower()
+
+        if cat_title_fi == "Esitysohjelma":
+            values.add("performance")
+
+        if cat_title_fi in (
+            "Kokemuspiste: avoin pelautus",
+            "Kokemuspiste: demotus",
+            "Kokemuspiste: muu",
+        ):
+            values.add("experience")
+
+        if cat_title_fi == "Miitti":
+            values.add("meetup")
+
+        if cat_title_fi in (
+            "Figupelit: avoin pelautus",
+            "Figupelit: demotus",
+            "Kokemuspiste: avoin pelautus",
+            "Kokemuspiste: demotus",
+            "LARP",
+            "Muu peliohjelma",
+            "Roolipeli",
+            "Turnaukset: figupelit",
+            "Turnaukset: korttipelit",
+            "Turnaukset: lautapelit",
+            "Turnaukset: muu",
+        ):
+            values.add("gaming")
+
+        if cat_title_fi in (
+            "Puheohjelma: esitelmä",
+            "Puheohjelma: paneeli",
+            "Puheohjelma: keskustelu",
+        ):
+            values.add("talk")
+
+        if cat_title_fi == "Tanssiohjelma" or "boff" in prog_title_lower or "polttopallo" in prog_title_lower:
+            values.add("activity")
+
+        if cat_title_fi in (
+            "Työpaja: figut",
+            "Työpaja: käsityö",
+            "Työpaja: musiikki",
+            "Työpaja: muu",
+        ):
+            values.add("workshop")
+
+        if "näyttely" in prog_title_lower:
+            values.add("exhibit")
+
+        return list(values)
+
+    def get_other_fields(self, programme: Programme) -> dict[str, str]:
+        other_fields = super().get_other_fields(programme)
+
+        other_fields.update(
+            **{
+                "ropecon:rpgSystem": programme.rpg_system,
+                "ropecon:otherAuthor": programme.other_author,
+                "konsti:minAttendance": programme.min_players,
+                "konsti:maxAttendance": programme.max_players,
+                "ropecon:numCharacters": programme.ropecon2018_characters,
+                "ropecon:workshopFee": programme.ropecon2023_workshop_fee,
+                "ropecon:contentWarnings": programme.ropecon2022_content_warnings,
+                "ropecon:accessibilityOther": programme.ropecon2023_other_accessibility_information,
+            }
+        )
+
+        return other_fields

--- a/backend/program_v2/models/meta.py
+++ b/backend/program_v2/models/meta.py
@@ -59,11 +59,14 @@ class ProgramV2EventMeta(EventMetaBase):
     @property
     def importer_class(self):
         from ..importers.default import DefaultImporter
+        from ..importers.ropecon2024 import RopeconImporter
         from ..importers.solmukohta2024 import SolmukohtaImporter
 
         match self.importer_name:
             case "solmukohta2024":
                 return SolmukohtaImporter
+            case "ropecon2024":
+                return RopeconImporter
             case _:
                 return DefaultImporter
 


### PR DESCRIPTION
- [ ] add dimensions other than `type`
- [ ] add proper Konstification logic (`konsti:signupType` in `otherFields`, see [spec](https://outline.con2.fi/doc/konsti-eb3wWRq4Ns))
- [x] there are duplicate program slugs under Ropecon, fsck