### PR TITLE
feat(emprinten): Finnish bank barcode and other stuff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ minimum_pre_commit_version: 2.15.0
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.13"
+    rev: "v0.4.9"
     hooks:
       - id: ruff
         args:

--- a/backend/core/management/commands/core_update_maysendinfo.py
+++ b/backend/core/management/commands/core_update_maysendinfo.py
@@ -16,7 +16,6 @@ class Command(BaseCommand):
         users = User.objects.filter(person__may_send_info=True)
         group.user_set.set(users, clear=True)
         logger.info(
-            "{num_users} users will now receive info spam".format(
-                num_users=Group.objects.get(name=settings.KOMPASSI_MAY_SEND_INFO_GROUP_NAME).user_set.count(),
-            )
+            "%d users will now receive info spam",
+            Group.objects.get(name=settings.KOMPASSI_MAY_SEND_INFO_GROUP_NAME).user_set.count(),
         )

--- a/backend/emprinten/admin.py
+++ b/backend/emprinten/admin.py
@@ -1,9 +1,19 @@
 from django.conf import settings
 from django.contrib import admin
+from django.urls import reverse
 
 from . import models
 
-admin.site.register(models.Project)
+
+@admin.register(models.Project)
+class ProjectAdmin(admin.ModelAdmin):
+    # noinspection PyMethodOverriding
+    def view_on_site(self, obj: models.Project) -> str | None:  # pyright: ignore reportIncompatibleMethodOverride
+        if obj.event is None:
+            return None
+        return reverse("emprinten_index", kwargs={"event": obj.event.slug, "slug": obj.slug})
+
+
 admin.site.register(models.FileVersion)
 
 

--- a/backend/emprinten/files.py
+++ b/backend/emprinten/files.py
@@ -13,12 +13,10 @@ Lut = dict[str, dict[str, str]]
 
 # noinspection PyPropertyDefinition
 class Pathlike(typing.Protocol):
-    def open(self, mode: str = "rb") -> io.BytesIO:
-        ...
+    def open(self, mode: str = "rb") -> io.BytesIO: ...
 
     @property
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
 
 def make_lut(file: Pathlike, encoding: str) -> Lut:

--- a/backend/emprinten/files.py
+++ b/backend/emprinten/files.py
@@ -111,7 +111,7 @@ def read_csv(csv_io: typing.TextIO) -> list[dict[str, str | dict[str, typing.Any
     header = next(reader)
     header = parse_header_names(header)
     for row_index, row in enumerate(reader):
-        row_data = OrderedDict(zip(header, row, strict=False))
+        row_data: dict[str, typing.Any] = OrderedDict(zip(header, row, strict=False))
         row_data.setdefault(
             "META",
             {

--- a/backend/emprinten/filters.py
+++ b/backend/emprinten/filters.py
@@ -2,6 +2,7 @@ import datetime
 import re
 
 import jinja2.nodes
+from django.conf import settings
 from jinja2 import is_undefined, pass_eval_context
 from jinja2.runtime import Undefined
 from markupsafe import Markup
@@ -14,7 +15,12 @@ SValue = str | Undefined
 def add_all_to(filters: dict[str, callable]) -> None:
     filters["nl2br"] = nl2br
     filters["filename"] = NameFactory.sanitize
-    filters.update(make_date_fns())
+    filters.update(
+        make_date_fns(
+            date_input=settings.DATE_FORMAT_STRFTIME,
+            datetime_input=settings.DATETIME_FORMAT_STRFTIME,
+        )
+    )
 
 
 @pass_eval_context
@@ -47,7 +53,7 @@ def make_date_fns(datetime_input: str | None = None, date_input: str | None = No
             value = datetime.datetime.strptime(value, datetime_input)
         return value.strftime(format)
 
-    def date(value: datetime.date | str | Undefined) -> SValue:
+    def date(value: datetime.date | str | Undefined) -> datetime.date | Undefined:
         if is_undefined(value):
             return value
         if isinstance(value, str):

--- a/backend/emprinten/filters.py
+++ b/backend/emprinten/filters.py
@@ -1,9 +1,11 @@
 import datetime
 import re
+import typing
 
 import jinja2.nodes
 from django.conf import settings
-from jinja2 import is_undefined, pass_eval_context
+from jinja2 import is_undefined as jinja_is_undefined
+from jinja2 import pass_eval_context
 from jinja2.runtime import Undefined
 from markupsafe import Markup
 
@@ -12,7 +14,7 @@ from .files import NameFactory
 SValue = str | Undefined
 
 
-def add_all_to(filters: dict[str, callable]) -> None:
+def add_all_to(filters: dict[str, typing.Callable]) -> None:
     filters["nl2br"] = nl2br
     filters["filename"] = NameFactory.sanitize
     filters.update(
@@ -23,9 +25,13 @@ def add_all_to(filters: dict[str, callable]) -> None:
     )
 
 
+def is_undefined(value: typing.Any) -> typing.TypeGuard[Undefined]:
+    return jinja_is_undefined(value)
+
+
 @pass_eval_context
 def nl2br(eval_ctx: jinja2.nodes.EvalContext, value: SValue, with_p: int = 0) -> Markup | SValue:
-    if is_undefined(value):
+    if not isinstance(value, str):
         return value
     br = "<br>\n"
 

--- a/backend/emprinten/functions.py
+++ b/backend/emprinten/functions.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import base64
+import datetime
+import typing
+
+from .svg_code128 import SvgCode128
+
+
+def get() -> dict[str, typing.Callable]:
+    return {
+        "fi_bank_barcode": fi_bank_barcode,
+    }
+
+
+class FiBankBarCode(typing.NamedTuple):
+    valid: bool
+    number: str
+    svg64: str
+
+    @classmethod
+    def invalid(cls) -> FiBankBarCode:
+        return FiBankBarCode(valid=False, number="", svg64="")
+
+
+def _number_or_none(number: str | int | None) -> int | None:
+    if isinstance(number, str):
+        if number.isdigit():
+            return int(number)
+    elif isinstance(number, int):
+        return number
+    return None
+
+
+FI_BANK_IBAN_LENGTH = 16
+FI_BANK_MAX_EUROCENTS = 99
+FI_BANK_MAX_EUROS = 1_000_000
+FI_BANK_MAX_REF_LENGTH = 20
+FI_BANK_VIRTUAL_BARCODE_LENGTH = 54
+
+
+def fi_bank_barcode(iban: str, euro: int, cents: int, viite: str | int, era: datetime.date | None) -> FiBankBarCode:
+    _euro = _number_or_none(euro)
+    _cents = _number_or_none(cents)
+    if iban is None or _euro is None or _cents is None or viite is None:
+        return FiBankBarCode.invalid()
+
+    if (
+        not iban
+        or not iban.startswith("FI")
+        or _cents < 0
+        or _cents > FI_BANK_MAX_EUROCENTS
+        or _euro < 0
+        or _euro >= FI_BANK_MAX_EUROS
+    ):
+        return FiBankBarCode.invalid()
+
+    iban = iban.replace(" ", "").removeprefix("FI")
+    if len(iban) != FI_BANK_IBAN_LENGTH or not iban.isdigit():
+        return FiBankBarCode.invalid()
+
+    if not isinstance(viite, str):
+        viite = str(viite)
+    viite = viite.replace(" ", "")
+    if len(viite) > FI_BANK_MAX_REF_LENGTH or not viite.isdigit():
+        return FiBankBarCode.invalid()
+
+    _era = era.strftime("%y%m%d") if era else "000000"
+    vv = f"4{iban}{_euro:06d}{_cents:02d}000{viite:0>20s}{_era}"
+    if len(vv) != FI_BANK_VIRTUAL_BARCODE_LENGTH:
+        return FiBankBarCode.invalid()
+
+    code = SvgCode128(vv)
+    svg = code.draw_svg()
+    svg64 = base64.b64encode(svg).decode("utf-8")
+    return FiBankBarCode(valid=True, number=vv, svg64=svg64)

--- a/backend/emprinten/renderer.py
+++ b/backend/emprinten/renderer.py
@@ -60,7 +60,7 @@ def find_main(files: typing.Iterable[FileVersion]) -> FileVersion | None:
 
 def find_lookup_tables(files: typing.Iterable[FileVersion]) -> dict[str, Lut]:
     return {
-        make_name(file_version.file.file_name): make_lut(file_version.data, "utf-8")
+        make_name(os.path.splitext(file_version.file.file_name)[0]): make_lut(file_version.data, "utf-8")
         for file_version in files
         if file_version.file.type == ProjectFile.Type.CSV
     }

--- a/backend/emprinten/svg_code128.py
+++ b/backend/emprinten/svg_code128.py
@@ -1,0 +1,54 @@
+import xml.dom
+
+from reportlab.graphics.barcode.code128 import Code128Auto
+
+DIM = "{0:.3f}pt"
+
+
+class SvgCode128(Code128Auto):
+    def __init__(self, value, **kwargs):
+        super().__init__(value, **kwargs)
+        self._blocks: list[tuple[float, float, float, float]] = []
+
+        # Assigned in reportlab.graphics.barcode.common.MultiWidthBarcode.computeSize
+        self._width: float
+        self._height: float
+
+    def draw(self) -> None:
+        raise NotImplementedError
+
+    # Separate function for different signature.
+    def draw_svg(self) -> bytes:
+        # Super implementation calls self.rect(..) repeatedly.
+        super().draw()
+
+        impl = xml.dom.getDOMImplementation()
+        doc = impl.createDocument("http://www.w3.org/2000/svg", "svg", None)
+        root = doc.documentElement
+
+        root.setAttribute("version", "1.1")
+        root.setAttribute("width", DIM.format(self._width))
+        root.setAttribute("height", DIM.format(self._height))
+
+        drawing = doc.createElement("g")
+        root.appendChild(drawing)
+
+        bg = doc.createElement("rect")
+        bg.setAttribute("width", DIM.format(self._width))
+        bg.setAttribute("height", DIM.format(self._height))
+        bg.setAttribute("style", "fill:#ffffff;")
+        drawing.appendChild(bg)
+
+        for block in self._blocks:
+            element = doc.createElement("rect")
+            element.setAttribute("x", DIM.format(block[0]))
+            element.setAttribute("y", DIM.format(block[1]))
+            element.setAttribute("width", DIM.format(block[2]))
+            element.setAttribute("height", DIM.format(block[3]))
+            element.setAttribute("style", "fill:#000000;")
+            drawing.appendChild(element)
+
+        return doc.toxml(encoding="utf-8")
+
+    def rect(self, x: float, y: float, w: float, h: float) -> None:
+        self._blocks.append((x, y, w, h))

--- a/backend/emprinten/tests.py
+++ b/backend/emprinten/tests.py
@@ -1,0 +1,99 @@
+import datetime
+
+import pytest
+
+from .functions import fi_bank_barcode
+
+
+@pytest.mark.parametrize(
+    ("iban", "euro", "cents", "viite", "era", "expect"),
+    [
+        # Test barcode content from "Pankkiviivakoodi-Opas", "Versio 5.3" by "Finanssiala"
+        # Lasku 1
+        (
+            "FI79 4405 2020 0360 82",
+            4883,
+            15,
+            "86851 62596 19897",
+            "12.6.2010",
+            "479440520200360820048831500000000868516259619897100612",
+        ),
+        # Lasku 3
+        (
+            "FI02 5000 4640 0013 02",
+            693,
+            80,
+            "69 87567 20834 35364",
+            "24.7.2011",
+            "402500046400013020006938000000069875672083435364110724",
+        ),
+        # Lasku 5, ei eräpäivää
+        (
+            "FI16 8000 1400 0502 67",
+            935,
+            85,
+            "78 77767 96566 28687",
+            None,
+            "416800014000502670009358500000078777679656628687000000",
+        ),
+        # Lasku 6, ei summaa
+        (
+            "FI73 3131 3001 0000 58",
+            0,
+            00,
+            "8 68624",
+            "9.8.2013",
+            "473313130010000580000000000000000000000000868624130809",
+        ),
+        # Lasku 7, max
+        (
+            "FI83 3301 0001 1007 75",
+            150000,
+            20,
+            "92125 37425 25398 97737",
+            "25.5.2016",
+            "483330100011007751500002000092125374252539897737160525",
+        ),
+        # Lasku 9, tulevaisuus
+        (
+            "FI92 3939 0001 0033 91",
+            0,
+            2,
+            "13 57914",
+            "24.12.2099",
+            "492393900010033910000000200000000000000001357914991224",
+        ),
+    ],
+)
+def test_fi_bank_barcode(iban: str, euro: int, cents: int, viite: str | int, era: str | None, expect: str) -> None:
+    _era = datetime.datetime.strptime(era, "%d.%m.%Y").date() if era else None
+
+    result = fi_bank_barcode(iban, euro, cents, viite, _era)
+    assert result.valid
+    assert result.number == expect
+
+
+@pytest.mark.parametrize(
+    ("iban", "euro", "cents", "viite", "era"),
+    [
+        # Wrong iban length
+        ("FI12 3456 7890 123", 1, 1, "13 57914", None),
+        # Wrong prefix
+        ("SE12 3456 7890 12", 1, 1, "13 57914", None),
+        # Invalid cents
+        ("FI12 3456 7890 12", 1, 100, "13 57914", None),
+        # Invalid cents
+        ("FI12 3456 7890 12", 1, -1, "13 57914", None),
+        # Invalid euros
+        ("FI12 3456 7890 12", 1_000_000, 0, "13 57914", None),
+        # Invalid euros
+        ("FI12 3456 7890 12", -1, 0, "13 57914", None),
+        # Requires V5 barcode which is not supported
+        ("FI12 3456 7890 12", 1, 0, "RF61 6987 5672 0839", None),
+    ],
+)
+def test_fi_bank_barcode_invalid(iban: str, euro: int, cents: int, viite: str | int, era: str | None) -> None:
+    _era = datetime.datetime.strptime(era, "%d.%m.%Y").date() if era else None
+
+    result = fi_bank_barcode(iban, euro, cents, viite, _era)
+    assert not result.valid

--- a/backend/emprinten/var_help.py
+++ b/backend/emprinten/var_help.py
@@ -9,16 +9,16 @@ from .renderer import _TemplateCompiler, files_to_vfs, find_main
 def _parse_node(node: jinja2.compiler.nodes.Node, out: set[str]):
     # XXX: This misses variables from includes / imports.
 
-    if hasattr(node, "nodes"):
+    if (nodes := getattr(node, "nodes", None)) is not None:
         # Classic tree, such as Template or Output.
-        for child in node.nodes:
+        for child in nodes:
             _parse_node(child, out)
-    if hasattr(node, "node"):
+    if (inner := getattr(node, "node", None)) is not None:
         # e.g. filter applied to variable reference
-        _parse_node(node.node, out)
-    if hasattr(node, "args"):
+        _parse_node(inner, out)
+    if (args := getattr(node, "args", None)) is not None:
         # e.g. variable references in macro args
-        for child in node.args:
+        for child in args:
             _parse_node(child, out)
     if isinstance(node, jinja2.compiler.nodes.Getattr):
         if isinstance(node.node, jinja2.compiler.nodes.Name) and node.node.name == "row":

--- a/backend/forms/utils/process_form_data.py
+++ b/backend/forms/utils/process_form_data.py
@@ -7,6 +7,7 @@ implementation.
 NOTE: The exact semantics of `process_form_data` are defined by and documented in
 `forms/tests.py:test_process_form_data`.
 """
+
 import decimal
 from collections.abc import Sequence
 from enum import Enum

--- a/backend/kompassi/settings.py
+++ b/backend/kompassi/settings.py
@@ -351,9 +351,9 @@ MESSAGE_TAGS = {
 
 KOMPASSI_APPLICATION_NAME = "Kompassi"
 KOMPASSI_INSTALLATION_NAME = env("KOMPASSI_INSTALLATION_NAME", default="Kompassi (DEV)")
-KOMPASSI_INSTALLATION_NAME_ILLATIVE = "Kompassin kehitys\u00ADinstanssiin" if DEBUG else "Kompassiin"
-KOMPASSI_INSTALLATION_NAME_GENITIVE = "Kompassin kehitys\u00ADinstanssin" if DEBUG else "Kompassin"
-KOMPASSI_INSTALLATION_NAME_PARTITIVE = "Kompassin kehitys\u00ADinstanssia" if DEBUG else "Kompassia"
+KOMPASSI_INSTALLATION_NAME_ILLATIVE = "Kompassin kehitys\u00adinstanssiin" if DEBUG else "Kompassiin"
+KOMPASSI_INSTALLATION_NAME_GENITIVE = "Kompassin kehitys\u00adinstanssin" if DEBUG else "Kompassin"
+KOMPASSI_INSTALLATION_NAME_PARTITIVE = "Kompassin kehitys\u00adinstanssia" if DEBUG else "Kompassia"
 KOMPASSI_INSTALLATION_SLUG = env("KOMPASSI_INSTALLATION_SLUG", default="turskadev")
 KOMPASSI_PRIVACY_POLICY_URL = "https://ry.tracon.fi/tietosuoja/rekisteriselosteet/kompassi"
 FEEDBACK_PRIVACY_POLICY_URL = "https://ry.tracon.fi/tietosuoja/rekisteriselosteet/kompassi-palaute"

--- a/backend/labour/models/roster.py
+++ b/backend/labour/models/roster.py
@@ -223,12 +223,7 @@ class Shift(models.Model, CsvExportMixin):
 
     def __str__(self):
         parts = [
-            "{interval} ({hours} h): {job_category_name} ({job_name})".format(
-                interval=format_interval(self.start_time, self.end_time),
-                hours=self.hours,
-                job_category_name=self.job.job_category.title if self.job and self.job.job_category else None,
-                job_name=self.job.title if self.job else None,
-            )
+            f"{format_interval(self.start_time, self.end_time)} ({self.hours} h): {self.job.job_category.title if self.job and self.job.job_category else None} ({self.job.title if self.job else None})"
         ]
 
         if self.notes:

--- a/backend/membership/models.py
+++ b/backend/membership/models.py
@@ -131,10 +131,7 @@ class Membership(models.Model, CsvExportMixin):
         return f"{self.person.surname}, {self.person.official_first_names}, {self.person.muncipality}"
 
     def __str__(self):
-        return "{organization}/{person}".format(
-            organization=self.organization.name if self.organization else None,
-            person=self.person.official_name if self.person else None,
-        )
+        return f"{self.organization.name if self.organization else None}/{self.person.official_name if self.person else None}"
 
     @classmethod
     def get_csv_fields(cls, unused_organization):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,13 +4,15 @@ line-length = 120
 [tool.ruff]
 target-version = "py312"
 line-length = 120
+
+[tool.ruff.lint]
 ignore-init-module-imports = true
 extend-select = [
     "B",
     "C",
     "I", # import sorting
     "PERF",
-    "PGH002",  # .warn is deprecated
+    "G010",  # .warn is deprecated
     "PGH004",  # specific noqa
     "PL",  # pylint
     "RET",
@@ -38,7 +40,7 @@ extend-ignore = [
     "PERF401", # manual-list-comprehension
 ]
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "**/__init__.py" = [
     "F401",  # imported but unused
 ]


### PR DESCRIPTION
Implemented by gluing reportlab Code128 generator to provide SVG image data URL to template. The compiler will then try to load its content (using _do_lookup), which we unpack and give back as data.

- Typing fixes per pyright.
- Style fixes per ruff.
- Fixes for date/datetime formatting and lookup table name (if used) provided to template.
- Added _View on site_ link to admin on Projects that are usable via the generator UI.