### PR TITLE
fix(core): Fix RegexValidators for slugs

### DIFF
--- a/backend/core/utils/model_utils.py
+++ b/backend/core/utils/model_utils.py
@@ -9,12 +9,12 @@ from django.forms import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 validate_slug = RegexValidator(
-    regex=r"[a-z0-9-]+",
+    regex=r"^[a-z0-9-]+$",
     message="Tekninen nimi saa sisältää vain pieniä kirjaimia, numeroita sekä väliviivoja.",
 )
 
 validate_slug_underscore = RegexValidator(
-    regex=r"[a-z0-9_]+",
+    regex=r"^[a-z0-9_]+$",
     message="Tekninen nimi saa sisältää vain pieniä kirjaimia, numeroita sekä alaviivoja.",
 )
 


### PR DESCRIPTION
RegexValidators validate_slug and validate_slug_underscore were missing the "^$" so they would never match.

```
In [1]: from core.utils import validate_slug
In [2]: print(validate_slug('asdf!asdf'))
None
```

Fixed:

```
In [1]: from core.utils import validate_slug
In [2]: print(validate_slug('asdf!asdf'))
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
```


