### PR TITLE
fix(forms): Validate model fields on CreateSurvey mutation

### DIFF
--- a/backend/forms/graphql/mutations/create_survey.py
+++ b/backend/forms/graphql/mutations/create_survey.py
@@ -26,5 +26,7 @@ class CreateSurvey(graphene.Mutation):
     ):
         event = Event.objects.get(slug=input.event_slug)
         graphql_check_model(Survey, event, info, "mutation")
-        survey = Survey.objects.create(event=event, slug=input.survey_slug)
+        survey = Survey(event=event, slug=input.survey_slug)
+        survey.full_clean()  # Validate fields
+        survey.save()
         return CreateSurvey(survey=survey)  # type: ignore


### PR DESCRIPTION
Validators are not run on Survey.objects.create() but need to be run separately before save(). This is by design in django, where validators run by ModelForm.

Needs validators fix https://github.com/con2/kompassi/pull/527 to work.

### Before

<img width="714" alt="Screenshot 2024-11-06 at 11 57 25" src="https://github.com/user-attachments/assets/b30d8677-10c4-4d6a-82dd-1efee43ee7b4">
<img width="520" alt="Screenshot 2024-11-06 at 11 57 42" src="https://github.com/user-attachments/assets/53601349-c9c4-4549-9b33-ba1fb66290e7">

### After

<img width="796" alt="Screenshot 2024-11-06 at 11 53 12" src="https://github.com/user-attachments/assets/0325baa5-d08a-4738-909d-1bf9302bd56e">
