### PR TITLE
Use h2 as intra teams fragment heading

### DIFF
--- a/backend/intra/templates/intra_teams_fragment.pug
+++ b/backend/intra/templates/intra_teams_fragment.pug
@@ -1,5 +1,5 @@
 for team in teams
-  h1= team.name
+  h2= team.name
 
   //- NOTE: our wp theme for some reason puts space between divs
   p


### PR DESCRIPTION
Tracon's website prefers team titles to be h2 elements