### PR TITLE
fix(tickets_v2): show default ticket quantity as empty instead of 0 in ticket order form (fixes #688)

### DIFF
--- a/frontend/src/app/[locale]/[eventSlug]/tickets/page.tsx
+++ b/frontend/src/app/[locale]/[eventSlug]/tickets/page.tsx
@@ -102,7 +102,7 @@ export default async function TicketsPage({ params }: Props) {
                         id={`quantity-${product.id}`}
                         name={`quantity-${product.id}`}
                         min={0}
-                        defaultValue={0}
+                        defaultValue=""
                         max={product.maxPerOrder}
                       />
                     ) : (

--- a/frontend/src/services/tickets.ts
+++ b/frontend/src/services/tickets.ts
@@ -67,7 +67,10 @@ export function getProductEntries(
     .filter(([key]) => key.startsWith("quantity-"))
     .map(
       ([key, value]) =>
-        [key.replace("quantity-", ""), parseInt(value as string, 10)] as const,
+        [
+          key.replace("quantity-", ""),
+          !value ? 0 : parseInt(value as string, 10),
+        ] as const,
     )
     .filter(([_, quantity]) => quantity > 0);
 }


### PR DESCRIPTION
Show default ticket quantity as empty instead of 0 in tickets v2 ticket order form.

The default of having the character "0" shown and not disappearing when users enter "1" results in several users ordering 10 tickets by accident. Having the field empty by default is better UX.