### PR TITLE
fix(tickets_v2): validate product_data against event catalog on order creation (#841)

### DIFF
--- a/kompassi/tickets_v2/optimized_server/models/order.py
+++ b/kompassi/tickets_v2/optimized_server/models/order.py
@@ -26,6 +26,7 @@ from ..utils.formatting import format_order_number, order_number_to_reference
 from .customer import Customer
 from .enums import PaymentStatus
 from .event import Event
+from .product_validation import validate_products
 from .ticket import reserve_tickets
 
 
@@ -91,6 +92,8 @@ class CreateOrderRequest(pydantic.BaseModel):
         Must be called within a transaction (SELECT FOR UPDATE SKIP LOCKED).
         NOTE: Keep in sync with the Django version of this function.
         """
+        await validate_products(db, event_id, self.products)
+
         async with db.cursor() as cursor:
             try:
                 await cursor.execute(

--- a/kompassi/tickets_v2/optimized_server/models/product_validation.py
+++ b/kompassi/tickets_v2/optimized_server/models/product_validation.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+from ..excs import InvalidProducts
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+validate_products_query = (Path(__file__).parent / "sql" / "get_products_for_validation.sql").read_bytes()
+
+
+class ProductValidationRow(NamedTuple):
+    superseded_by_id: int | None
+    available_from: datetime | None
+    available_until: datetime | None
+
+
+def _check_products(
+    products: dict[int, int],
+    rows: dict[int, ProductValidationRow],
+    *,
+    enforce_availability: bool,
+    now: datetime,
+) -> None:
+    if not any(quantity > 0 for quantity in products.values()):
+        raise InvalidProducts("Order must contain at least one product with a positive quantity.")
+
+    for product_id in products:
+        row = rows.get(product_id)
+        if row is None:
+            raise InvalidProducts(f"Product {product_id} does not belong to this event.")
+
+        if row.superseded_by_id is not None:
+            raise InvalidProducts(f"Product {product_id} has been superseded.")
+
+        if enforce_availability and not (
+            row.available_from is not None
+            and row.available_from <= now
+            and (row.available_until is None or now < row.available_until)
+        ):
+            raise InvalidProducts(f"Product {product_id} is not currently on sale.")
+
+
+async def validate_products(db: AsyncConnection, event_id: int, products: dict[int, int]) -> None:
+    """
+    Public order creation policy: every product must belong to the event, be the
+    current (non-superseded) version, and be within its availability window.
+
+    NOTE: Keep in sync with validate_products_django.
+    """
+    async with db.cursor() as cursor:
+        await cursor.execute(validate_products_query, dict(event_id=event_id, product_ids=list(products)))
+        rows = {
+            product_id: ProductValidationRow(superseded_by_id, available_from, available_until)
+            for product_id, superseded_by_id, available_from, available_until in await cursor.fetchall()
+        }
+
+    _check_products(products, rows, enforce_availability=True, now=datetime.now(UTC))
+
+
+def validate_products_django(event_id: int, products: dict[int, int]) -> None:
+    """
+    Admin order creation policy: every product must belong to the event and be the
+    current (non-superseded) version. Unlike the public policy, the availability
+    window is not enforced, so admins can create orders for products that are not
+    currently on public sale.
+
+    NOTE: Keep in sync with validate_products.
+    """
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+        cursor.execute(validate_products_query.decode(), dict(event_id=event_id, product_ids=list(products)))
+        rows = {
+            product_id: ProductValidationRow(superseded_by_id, available_from, available_until)
+            for product_id, superseded_by_id, available_from, available_until in cursor.fetchall()
+        }
+
+    _check_products(products, rows, enforce_availability=False, now=datetime.now(UTC))

--- a/kompassi/tickets_v2/optimized_server/models/quota.py
+++ b/kompassi/tickets_v2/optimized_server/models/quota.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ..excs import InvalidProducts
+
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
@@ -50,7 +52,12 @@ async def get_expected_tickets_for_products(
 
     expected_quantities_by_quota_id: dict[int, int] = {}
     for product_id, quantity in products.items():
-        for quota_id in quota_ids_by_product_id[product_id]:
+        try:
+            quota_ids = quota_ids_by_product_id[product_id]
+        except KeyError:
+            raise InvalidProducts(f"Product {product_id} has no quotas in this event.") from None
+
+        for quota_id in quota_ids:
             expected_quantities_by_quota_id.setdefault(quota_id, 0)
             expected_quantities_by_quota_id[quota_id] += quantity
 

--- a/kompassi/tickets_v2/optimized_server/models/sql/get_products_for_validation.sql
+++ b/kompassi/tickets_v2/optimized_server/models/sql/get_products_for_validation.sql
@@ -1,0 +1,10 @@
+select
+  id,
+  superseded_by_id,
+  available_from,
+  available_until
+from
+  tickets_v2_product
+where
+  event_id = %(event_id)s
+  and id = any(%(product_ids)s)

--- a/kompassi/tickets_v2/tests.py
+++ b/kompassi/tickets_v2/tests.py
@@ -25,6 +25,9 @@ from kompassi.tickets_v2.models.payment_stamp import PaymentStamp
 from kompassi.tickets_v2.models.product import Product
 from kompassi.tickets_v2.models.quota import Quota
 from kompassi.tickets_v2.models.receipt import PendingReceipt
+from kompassi.tickets_v2.models.ticket import Ticket
+from kompassi.tickets_v2.optimized_server.excs import InvalidProducts
+from kompassi.tickets_v2.optimized_server.excs import NotEnoughTickets as OptimizedNotEnoughTickets
 from kompassi.tickets_v2.optimized_server.models.api import CreateOrderResponse, GetOrderResponse, GetProductsResponse
 from kompassi.tickets_v2.optimized_server.models.customer import Customer
 from kompassi.tickets_v2.optimized_server.models.enums import (
@@ -35,11 +38,13 @@ from kompassi.tickets_v2.optimized_server.models.enums import (
     ReceiptType,
 )
 from kompassi.tickets_v2.optimized_server.models.order import CreateOrderRequest, OrderProduct, VatBreakdownLine
+from kompassi.tickets_v2.optimized_server.models.product_validation import ProductValidationRow, _check_products
 from kompassi.tickets_v2.optimized_server.providers.paytrail import PaymentCallback, PaytrailStatus
 from kompassi.tickets_v2.optimized_server.utils.formatting import format_vat_rate
 from kompassi.tickets_v2.optimized_server.utils.paytrail_hmac import calculate_hmac
 from kompassi.tickets_v2.optimized_server.utils.uuid7 import uuid7
 from kompassi.tickets_v2.reports.vat_by_month import VatByMonth
+from kompassi.tickets_v2.utils.create_order import create_order
 
 PAYTRAIL_TEST_ACCOUNT = "375917"
 PAYTRAIL_TEST_SECRET = "SAIPPUAKAUPPIAS"
@@ -1865,3 +1870,200 @@ def test_receipt_type_refused_for_flagged_order(quota_product):
 
     with pytest.raises(ValueError, match="paid after cancellation"):
         PendingReceipt.from_order(order)
+
+
+# ---------------------------------------------------------------------------
+# Product data validation on order creation (#841)
+# ---------------------------------------------------------------------------
+
+
+def _dummy_customer() -> Customer:
+    return Customer(first_name="John", last_name="Doe", email="john.doe@example.com")
+
+
+def _make_validation_product(event: Event, quota: Quota | None = None, **kwargs) -> Product:
+    product = Product.objects.create(
+        event=event,
+        title="Test product",
+        description="",
+        price=Decimal("10.00"),
+        vat_percentage=Decimal("25.50"),
+        **kwargs,
+    )
+    if quota is not None:
+        product.quotas.add(quota)
+    return product
+
+
+@pytest.fixture
+def validation_event(cancellation_event: Event):
+    """
+    A quota with one free ticket, so create_order() (admin path) can be exercised
+    end to end: past validation and through to a successful ticket reservation.
+    """
+    event = cancellation_event
+    quota = Quota.objects.create(event=event, name="Validation quota")
+    Ticket.objects.create(event=event, quota=quota)
+    return event, quota
+
+
+@pytest.mark.django_db
+def test_create_order_admin_rejects_foreign_event_product(validation_event):
+    event, _quota = validation_event
+    other_event, _ = Event.get_or_create_dummy(name="Other event #841 foreign")
+    foreign_product = _make_validation_product(other_event)
+
+    with pytest.raises(InvalidProducts):
+        create_order(event, _dummy_customer(), {foreign_product.id: 1})
+
+    assert not Order.objects.filter(event=event).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_rejects_mixed_foreign_and_own_products(validation_event):
+    event, quota = validation_event
+    own_product = _make_validation_product(event, quota)
+    other_event, _ = Event.get_or_create_dummy(name="Other event #841 mixed")
+    foreign_product = _make_validation_product(other_event)
+
+    with pytest.raises(InvalidProducts):
+        create_order(event, _dummy_customer(), {own_product.id: 1, foreign_product.id: 1})
+
+    assert not Order.objects.filter(event=event).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_rejects_superseded_product(validation_event):
+    event, quota = validation_event
+    old_product = _make_validation_product(event, quota)
+    new_product = _make_validation_product(event, quota)
+    old_product.superseded_by = new_product
+    old_product.save(update_fields=["superseded_by"])
+
+    with pytest.raises(InvalidProducts):
+        create_order(event, _dummy_customer(), {old_product.id: 1})
+
+    assert not Order.objects.filter(event=event).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_ignores_availability_window(validation_event):
+    """
+    Per the module docstring of kompassi.tickets_v2.utils.create_order, the admin
+    path intentionally does not enforce the availability window, so a product with
+    no sale window configured must still be orderable here.
+    """
+    event, quota = validation_event
+    product = _make_validation_product(event, quota, available_from=None, available_until=None)
+
+    order = create_order(event, _dummy_customer(), {product.id: 1})
+
+    assert Order.objects.filter(event=event, id=order.id).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_rejects_product_with_no_quota_links(validation_event):
+    """
+    A product that belongs to the event and is not superseded, but has no quotas
+    linked to it, must be rejected rather than crashing with the KeyError that
+    get_expected_tickets_for_products used to propagate. create_order() only
+    documents that it must run inside a transaction (as its real caller,
+    CreateOrder.mutate, does via @transaction.atomic) rather than wrapping itself,
+    so the test must reproduce that same wrapping to see the insert rolled back.
+    """
+    from django.db import transaction
+
+    event, _quota = validation_event
+    product = _make_validation_product(event, quota=None)
+
+    with pytest.raises(InvalidProducts), transaction.atomic():
+        create_order(event, _dummy_customer(), {product.id: 1})
+
+    assert not Order.objects.filter(event=event).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_rejects_all_zero_quantities(validation_event):
+    event, quota = validation_event
+    product = _make_validation_product(event, quota)
+
+    with pytest.raises(InvalidProducts):
+        create_order(event, _dummy_customer(), {product.id: 0})
+
+    assert not Order.objects.filter(event=event).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_happy_path_unaffected(validation_event):
+    event, quota = validation_event
+    product = _make_validation_product(event, quota)
+
+    order = create_order(event, _dummy_customer(), {product.id: 1})
+
+    assert Order.objects.filter(event=event, id=order.id).exists()
+
+
+@pytest.mark.django_db
+def test_create_order_admin_not_enough_tickets_unaffected(validation_event):
+    """
+    A product with quota links but no free tickets must still surface as
+    NotEnoughTickets, not get swallowed by the new InvalidProducts handling.
+    """
+    event, _quota = validation_event
+    exhausted_quota = Quota.objects.create(event=event, name="Exhausted quota")
+    product = _make_validation_product(event, exhausted_quota)
+
+    with pytest.raises(OptimizedNotEnoughTickets):
+        create_order(event, _dummy_customer(), {product.id: 1})
+
+
+def test_check_products_rejects_unknown_product():
+    with pytest.raises(InvalidProducts):
+        _check_products({1: 1}, {}, enforce_availability=True, now=datetime.now(UTC))
+
+
+def test_check_products_rejects_superseded_product():
+    rows = {1: ProductValidationRow(superseded_by_id=2, available_from=None, available_until=None)}
+
+    with pytest.raises(InvalidProducts):
+        _check_products({1: 1}, rows, enforce_availability=True, now=datetime.now(UTC))
+
+
+def test_check_products_rejects_all_zero_quantities():
+    now = datetime.now(UTC)
+    rows = {
+        1: ProductValidationRow(superseded_by_id=None, available_from=now - timedelta(days=1), available_until=None)
+    }
+
+    with pytest.raises(InvalidProducts):
+        _check_products({1: 0}, rows, enforce_availability=True, now=now)
+
+
+def test_check_products_public_policy_enforces_availability_window():
+    now = datetime.now(UTC)
+
+    not_yet_on_sale = {
+        1: ProductValidationRow(superseded_by_id=None, available_from=now + timedelta(days=1), available_until=None)
+    }
+    with pytest.raises(InvalidProducts):
+        _check_products({1: 1}, not_yet_on_sale, enforce_availability=True, now=now)
+
+    no_longer_on_sale = {
+        1: ProductValidationRow(
+            superseded_by_id=None, available_from=now - timedelta(days=2), available_until=now - timedelta(days=1)
+        )
+    }
+    with pytest.raises(InvalidProducts):
+        _check_products({1: 1}, no_longer_on_sale, enforce_availability=True, now=now)
+
+    on_sale_open_ended = {
+        1: ProductValidationRow(superseded_by_id=None, available_from=now - timedelta(days=1), available_until=None)
+    }
+    _check_products({1: 1}, on_sale_open_ended, enforce_availability=True, now=now)  # must not raise
+
+
+def test_check_products_admin_policy_ignores_availability_window():
+    now = datetime.now(UTC)
+    never_on_sale = {1: ProductValidationRow(superseded_by_id=None, available_from=None, available_until=None)}
+
+    _check_products({1: 1}, never_on_sale, enforce_availability=False, now=now)  # must not raise

--- a/kompassi/tickets_v2/utils/create_order.py
+++ b/kompassi/tickets_v2/utils/create_order.py
@@ -29,6 +29,7 @@ from ..models.order import Order
 from ..optimized_server.excs import InvalidProducts, NotEnoughTickets, UnsaneSituation
 from ..optimized_server.models.customer import Customer
 from ..optimized_server.models.order import ProductsDict, validate_products_dict
+from ..optimized_server.models.product_validation import validate_products_django
 from ..optimized_server.utils.uuid7 import uuid7
 
 OPTIMIZED_SERVER_SQL_DIR = Path(__file__).parent.parent / "optimized_server" / "models" / "sql"
@@ -45,6 +46,8 @@ def create_order(
     Preferred way to create orders from Django code.
     NOTE: Must be called within a transaction (uses SELECT FOR UPDATE SKIP LOCKED).
     """
+    validate_products_django(event.id, products)
+
     with connection.cursor() as cursor:
         try:
             cursor.execute(
@@ -141,7 +144,12 @@ def get_expected_tickets_for_products(
 
     expected_quantities_by_quota_id: dict[int, int] = {}
     for product_id, quantity in products.items():
-        for quota_id in quota_ids_by_product_id[product_id]:
+        try:
+            quota_ids = quota_ids_by_product_id[product_id]
+        except KeyError:
+            raise InvalidProducts(f"Product {product_id} has no quotas in this event.") from None
+
+        for quota_id in quota_ids:
             expected_quantities_by_quota_id.setdefault(quota_id, 0)
             expected_quantities_by_quota_id[quota_id] += quantity
 


### PR DESCRIPTION
products in POST /api/tickets-v2/{event_slug}/orders/ was effectively
client-controlled: forged ids from other events, superseded product
versions, or products outside their sale window could be inserted into an
order despite create_order.sql pricing only from the event's own current
catalog. A crafted payload could also submit an all-zero-quantity basket
for a free garbage order.

Add a shared validate_products/validate_products_django helper enforcing,
before insert, that every product belongs to the event, is not superseded,
and (public path only) is within its availability window, plus at least
one positive quantity. Also turn the KeyError get_expected_tickets_for_products
raised for a product with no quota links into InvalidProducts so that case
(and any future caller skipping validation) fails closed with 400 rather
than a bare crash.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

fixes #841 
