### PR TITLE
fix(tickets_v2): include refunds in the monthly VAT report

### DIFF
--- a/kompassi/tickets_v2/reports/sql/report_vat_by_month.sql
+++ b/kompassi/tickets_v2/reports/sql/report_vat_by_month.sql
@@ -1,23 +1,57 @@
-select
-  to_char(
-    date_trunc(
-      'month',
-      to_timestamp(
-        ('x' || left(replace(o.id::text, '-', ''), 12))::bit(48)::bigint / 1000.0
-      ) at time zone %(event_timezone)s
-    ),
-    'YYYY-MM'
-  ) as year_month,
-  p.vat_percentage,
-  sum(p.price * pd.quantity::numeric * p.vat_percentage / (100 + p.vat_percentage)) as vat_amount
-from
-  tickets_v2_order o
+with order_lines as (
+  select o.id as order_id, p.vat_percentage as vat_rate,
+         sum(p.price * pd.quantity::numeric) as gross
+  from tickets_v2_order o
   join lateral jsonb_each_text(o.product_data) as pd(product_id, quantity) on true
   join tickets_v2_product p on p.id = pd.product_id::int
-where
-  o.event_id = %(event_id)s
-  and o.cached_status = any(%(paid_statuses)s::tickets_v2_paymentstatus[])
-  and pd.quantity::int > 0
-  and p.vat_percentage > 0
+  where o.event_id = %(event_id)s and pd.quantity::int > 0 and p.vat_percentage > 0
+  group by 1, 2
+),
+paid as (
+  select
+    order_id,
+    to_char(
+      date_trunc(
+        'month',
+        to_timestamp(
+          ('x' || left(replace(min(id::text), '-', ''), 12))::bit(48)::bigint / 1000.0
+        ) at time zone %(event_timezone)s
+      ),
+      'YYYY-MM'
+    ) as month
+  from tickets_v2_paymentstamp
+  where event_id = %(event_id)s and status = 'PAID'
+  group by order_id
+),
+refunded as (
+  select
+    order_id,
+    to_char(
+      date_trunc(
+        'month',
+        to_timestamp(
+          ('x' || left(replace(min(id::text), '-', ''), 12))::bit(48)::bigint / 1000.0
+        ) at time zone %(event_timezone)s
+      ),
+      'YYYY-MM'
+    ) as month
+  from tickets_v2_paymentstamp
+  where event_id = %(event_id)s and status = 'REFUNDED'
+  group by order_id
+),
+movements as (
+  select paid.month, ol.vat_rate, ol.gross as amount, 1 as sign
+  from order_lines ol join paid using (order_id)
+  union all
+  select refunded.month, ol.vat_rate, ol.gross, -1
+  from order_lines ol join paid using (order_id) join refunded using (order_id)
+)
+select
+  month, vat_rate,
+  sum(case when sign > 0 then amount else 0 end) as sold,
+  sum(case when sign < 0 then -amount else 0 end) as returned,
+  sum(sign * amount) as net,
+  sum(sign * round(amount * vat_rate / (100 + vat_rate), 2)) as vat
+from movements
 group by 1, 2
 order by 1, 2

--- a/kompassi/tickets_v2/reports/vat_by_month.py
+++ b/kompassi/tickets_v2/reports/vat_by_month.py
@@ -8,10 +8,9 @@ from django.db import connection
 from kompassi.core.models.event import Event
 from kompassi.graphql_api.language import DEFAULT_LANGUAGE
 from kompassi.reports.models.column import Column
-from kompassi.reports.models.enums import TypeOfColumn
+from kompassi.reports.models.enums import TotalBy, TypeOfColumn
 from kompassi.reports.models.report import Report
 
-from ..optimized_server.models.enums import PaymentStatus
 from ..optimized_server.utils.formatting import format_vat_rate
 
 SQL_DIR = Path(__file__).parent / "sql"
@@ -22,36 +21,33 @@ TITLE = dict(
     sv="Moms per månad",
 )
 MONTH_COLUMN_TITLE = dict(fi="Kuukausi", en="Month", sv="Månad")
-TOTAL_COLUMN_TITLE = dict(fi="Yhteensä", en="Total", sv="Totalt")
+VAT_RATE_COLUMN_TITLE = dict(fi="ALV-kanta", en="VAT rate", sv="Momssats")
+SOLD_COLUMN_TITLE = dict(fi="Myynti", en="Sold", sv="Försäljning")
+RETURNED_COLUMN_TITLE = dict(fi="Palautukset", en="Returned", sv="Återbetalningar")
+NET_COLUMN_TITLE = dict(fi="Netto", en="Net", sv="Netto")
+VAT_COLUMN_TITLE = dict(fi="Maksettava vero", en="Tax payable", sv="Moms att betala")
 FOOTER = dict(
     fi=(
-        "Vain maksetut tilaukset on laskettu mukaan. Hyvitetyt tilaukset näkyvät "
-        "alkuperäisen myyntikuukauden kohdalla; hyvityksiä ei vähennetä."
+        "Myynti kirjataan sille kuukaudelle, jona maksu on kirjattu, ja palautus sille "
+        "kuukaudelle, jona hyvitys on kirjattu. Summat sisältävät arvonlisäveron. "
+        "Maksettava vero on laskettu nettomyynnistä ja voi olla negatiivinen. Palautukset, "
+        "jotka ovat vielä kesken maksupalveluntarjoajalla, eivät näy ennen kuin ne on vahvistettu."
     ),
     en=(
-        "Only paid orders are included. Refunded orders are shown in the month of "
-        "the original sale; refunds are not subtracted."
+        "A sale is counted in the month the payment was recorded, and a return in the month "
+        "the refund was recorded. Amounts include VAT. Tax payable is computed on net sales "
+        "and can be negative. Refunds still pending at the payment provider are not counted "
+        "until confirmed."
     ),
     sv=(
-        "Endast betalda beställningar ingår. Återbetalda beställningar visas under "
-        "den ursprungliga försäljningsmånaden; återbetalningar dras inte av."
+        "En försäljning räknas till den månad då betalningen registrerades, och en "
+        "återbetalning till den månad då återbetalningen registrerades. Beloppen inkluderar "
+        "moms. Moms att betala beräknas på nettoförsäljningen och kan vara negativ. "
+        "Återbetalningar som fortfarande väntar hos betalningsleverantören räknas inte "
+        "förrän de bekräftats."
     ),
 )
 CENT = Decimal("0.01")
-
-# Orders in these statuses have been paid at some point. A later refund must not
-# retroactively remove the sale from the month it was made in, as the VAT for
-# that month may already have been filed.
-EVER_PAID_STATUSES = [
-    PaymentStatus.PAID,
-    PaymentStatus.REFUND_REQUESTED,
-    PaymentStatus.REFUND_FAILED,
-    PaymentStatus.REFUNDED,
-]
-
-
-def _vat_column_title(rate: Decimal) -> dict[str, str]:
-    return {lang: f"{format_vat_rate(rate, lang)}%" for lang in ("fi", "en", "sv")}
 
 
 class VatByMonth:
@@ -65,14 +61,9 @@ class VatByMonth:
                 dict(
                     event_id=event.id,
                     event_timezone=event.timezone_name,
-                    paid_statuses=[status.value for status in EVER_PAID_STATUSES],
                 ),
             )
             raw_rows = cursor.fetchall()
-
-        vat_rates: list[Decimal] = sorted({row[1] for row in raw_rows})
-        months: list[str] = sorted({row[0] for row in raw_rows})
-        data: dict[tuple[str, Decimal], Decimal] = {(row[0], row[1]): row[2] for row in raw_rows}
 
         columns: list[Column] = [
             Column(
@@ -82,31 +73,45 @@ class VatByMonth:
                 # NOTE: total_by defaults to SUM, which is what makes the total
                 # row label show "Total" in column 0 (see Report.get_total_row).
             ),
-            *(
-                Column(
-                    slug=f"vat_{rate}",
-                    title=_vat_column_title(rate),
-                    type=TypeOfColumn.CURRENCY,
-                )
-                for rate in vat_rates
+            Column(
+                slug="vat_rate",
+                title=VAT_RATE_COLUMN_TITLE,
+                type=TypeOfColumn.STRING,
+                total_by=TotalBy.NONE,
             ),
             Column(
-                slug="total",
-                title=TOTAL_COLUMN_TITLE,
+                slug="sold",
+                title=SOLD_COLUMN_TITLE,
+                type=TypeOfColumn.CURRENCY,
+            ),
+            Column(
+                slug="returned",
+                title=RETURNED_COLUMN_TITLE,
+                type=TypeOfColumn.CURRENCY,
+            ),
+            Column(
+                slug="net",
+                title=NET_COLUMN_TITLE,
+                type=TypeOfColumn.CURRENCY,
+            ),
+            Column(
+                slug="vat",
+                title=VAT_COLUMN_TITLE,
                 type=TypeOfColumn.CURRENCY,
             ),
         ]
 
-        rows: list[list] = []
-        for month in months:
-            row: list = [month]
-            row_total = Decimal(0)
-            for rate in vat_rates:
-                vat = data.get((month, rate), Decimal(0)).quantize(CENT)
-                row.append(float(vat))
-                row_total += vat
-            row.append(float(row_total))
-            rows.append(row)
+        rows: list[list] = [
+            [
+                month,
+                f"{format_vat_rate(vat_rate, lang)}%",
+                float(sold.quantize(CENT)),
+                float(returned.quantize(CENT)),
+                float(net.quantize(CENT)),
+                float(vat.quantize(CENT)),
+            ]
+            for month, vat_rate, sold, returned, net, vat in raw_rows
+        ]
 
         return Report(
             slug="vat_by_month",

--- a/kompassi/tickets_v2/tests.py
+++ b/kompassi/tickets_v2/tests.py
@@ -433,20 +433,24 @@ def _make_order(
 
 @pytest.fixture
 def vat_report_event(db):
+    from kompassi.tickets_v2.models.receipt import Receipt
+
     event, _ = Event.get_or_create_dummy(name="VAT report test event")
     # Sanity-check the timezone the report relies on for month bucketing.
     assert event.timezone_name == "Europe/Helsinki"
     Order.ensure_partition(event)
+    PaymentStamp.ensure_partition(event)
+    Receipt.ensure_partition(event)
     return event
 
 
 @pytest.mark.django_db
 def test_vat_by_month_report_empty(vat_report_event: Event):
-    """No orders → no rows, but the report still renders with a month column."""
+    """No orders → no rows, but the report still renders with the fixed columns."""
     report = VatByMonth.report(vat_report_event, "en")
     assert report.slug == "vat_by_month"
     assert report.rows == []
-    assert [c.slug for c in report.columns] == ["month", "total"]
+    assert [c.slug for c in report.columns] == ["month", "vat_rate", "sold", "returned", "net", "vat"]
     assert report.total_row is None  # has_total_row is False when there are no rows
 
 
@@ -481,46 +485,50 @@ def test_vat_by_month_report_basic(vat_report_event: Event):
         vat_percentage=Decimal(0),
     )
 
-    # Jan 2026 (Helsinki): 1× standard → 25.5% column = 25.50
-    _make_order(vat_report_event, datetime(2026, 1, 15, 12, 0, tzinfo=UTC), {standard.id: 1})
-    # Feb 2026 (Helsinki): 1× standard + 2× reduced → 25.5% = 25.50, 14% = 28.00
-    _make_order(vat_report_event, datetime(2026, 2, 10, 12, 0, tzinfo=UTC), {standard.id: 1, reduced.id: 2})
-    # Unpaid Feb order (must be excluded)
+    # Jan 2026 (Helsinki): 1× standard, paid at order time → 25.5% row = 125.50
+    jan_when = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+    jan_order = _make_order(vat_report_event, jan_when, {standard.id: 1})
+    _add_stamp(vat_report_event, jan_order, status=PaymentStatus.PAID, when=jan_when)
+
+    # Feb 2026 (Helsinki): 1× standard + 2× reduced, paid at order time
+    feb_when = datetime(2026, 2, 10, 12, 0, tzinfo=UTC)
+    feb_order = _make_order(vat_report_event, feb_when, {standard.id: 1, reduced.id: 2})
+    _add_stamp(vat_report_event, feb_order, status=PaymentStatus.PAID, when=feb_when)
+
+    # Unpaid Feb order (no PAID stamp, must be excluded)
     _make_order(
         vat_report_event,
         datetime(2026, 2, 20, 12, 0, tzinfo=UTC),
         {standard.id: 1},
         status=PaymentStatus.PENDING,
     )
-    # Paid zero-VAT Feb order (must be excluded)
-    _make_order(vat_report_event, datetime(2026, 2, 25, 12, 0, tzinfo=UTC), {zero_rated.id: 1})
+    # Paid zero-VAT Feb order (must be excluded, its only line has vat_percentage=0)
+    zero_when = datetime(2026, 2, 25, 12, 0, tzinfo=UTC)
+    zero_order = _make_order(vat_report_event, zero_when, {zero_rated.id: 1})
+    _add_stamp(vat_report_event, zero_order, status=PaymentStatus.PAID, when=zero_when)
 
     report = VatByMonth.report(vat_report_event, "en")
 
     column_slugs = [c.slug for c in report.columns]
-    assert column_slugs == ["month", "vat_14.00", "vat_25.50", "total"]
+    assert column_slugs == ["month", "vat_rate", "sold", "returned", "net", "vat"]
 
-    assert len(report.rows) == 2
-    jan, feb = report.rows
-    assert jan == ["2026-01", 0.00, 25.50, 25.50]
-    assert feb == ["2026-02", 28.00, 25.50, 53.50]
+    assert report.rows == [
+        ["2026-01", "25.5%", 125.50, 0.00, 125.50, 25.50],
+        ["2026-02", "14%", 228.00, 0.00, 228.00, 28.00],
+        ["2026-02", "25.5%", 125.50, 0.00, 125.50, 25.50],
+    ]
 
-    # Total row sums each column (skipping the month column, which is total_by=NONE).
-    assert report.total_row is not None
-    month_label, total_14, total_25_5, grand_total = report.total_row
-    assert month_label == "Total"
-    assert total_14 == pytest.approx(28.00)
-    assert total_25_5 == pytest.approx(51.00)
-    assert grand_total == pytest.approx(79.00)
+    assert report.total_row == ["Total", "", 479.00, 0.00, 479.00, 79.00]
 
 
 @pytest.mark.django_db
-def test_vat_by_month_report_refund_does_not_change_history(vat_report_event: Event):
+def test_vat_by_month_report_refund_lands_in_refund_month(vat_report_event: Event):
     """
-    Once an order has been paid, its VAT belongs to the month of the sale even if
-    the order is later refunded — the VAT for that month may already have been
-    filed, so the report must not change retroactively. (The footer tells the
-    reader that refunds are not subtracted.)
+    A sale belongs to the month of its first PAID stamp, a return to the month
+    of its first REFUNDED stamp — they can land in different months and the
+    sale's month is not touched by the later refund. A REFUND_REQUESTED stamp
+    (CREATE_REFUND_SUCCESS type) alone does not make an order a return yet:
+    the money has not been confirmed returned.
     """
     product = Product.objects.create(
         event=vat_report_event,
@@ -530,23 +538,46 @@ def test_vat_by_month_report_refund_does_not_change_history(vat_report_event: Ev
         vat_percentage=Decimal("25.50"),
     )
 
-    _make_order(vat_report_event, datetime(2026, 1, 15, 12, 0, tzinfo=UTC), {product.id: 1})
-    for status in (
-        PaymentStatus.REFUND_REQUESTED,
-        PaymentStatus.REFUND_FAILED,
-        PaymentStatus.REFUNDED,
-    ):
-        _make_order(vat_report_event, datetime(2026, 1, 20, 12, 0, tzinfo=UTC), {product.id: 1}, status=status)
+    refunded_order = _make_order(vat_report_event, datetime(2026, 1, 15, 12, 0, tzinfo=UTC), {product.id: 1})
+    _add_stamp(
+        vat_report_event, refunded_order, status=PaymentStatus.PAID, when=datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+    )
+    _add_stamp(
+        vat_report_event,
+        refunded_order,
+        status=PaymentStatus.REFUNDED,
+        type=PaymentStampType.MANUAL_REFUND,
+        when=datetime(2026, 2, 10, 12, 0, tzinfo=UTC),
+    )
+
+    pending_refund_order = _make_order(vat_report_event, datetime(2026, 1, 20, 12, 0, tzinfo=UTC), {product.id: 1})
+    _add_stamp(
+        vat_report_event,
+        pending_refund_order,
+        status=PaymentStatus.PAID,
+        when=datetime(2026, 1, 20, 12, 0, tzinfo=UTC),
+    )
+    _add_stamp(
+        vat_report_event,
+        pending_refund_order,
+        status=PaymentStatus.REFUND_REQUESTED,
+        type=PaymentStampType.CREATE_REFUND_SUCCESS,
+        when=datetime(2026, 2, 15, 12, 0, tzinfo=UTC),
+    )
 
     report = VatByMonth.report(vat_report_event, "en")
-    assert report.rows == [["2026-01", 4 * 25.50, 4 * 25.50]]
+    assert report.rows == [
+        ["2026-01", "25.5%", 251.00, 0.00, 251.00, 51.00],
+        ["2026-02", "25.5%", 0.00, -125.50, -125.50, -25.50],
+    ]
 
 
 @pytest.mark.django_db
-def test_vat_by_month_report_timezone_boundary(vat_report_event: Event):
+def test_vat_by_month_report_sale_month_is_payment_month(vat_report_event: Event):
     """
-    An order at 23:30 UTC on Jan 31 falls on Feb 1 in Helsinki (UTC+2),
-    so the report should bucket it in February.
+    An order created just before midnight UTC but paid a bit later, once the
+    payment moment has already rolled over into February in Helsinki (UTC+2),
+    is bucketed by the payment month, not the order's creation month.
     """
     product = Product.objects.create(
         event=vat_report_event,
@@ -555,37 +586,108 @@ def test_vat_by_month_report_timezone_boundary(vat_report_event: Event):
         price=Decimal("125.50"),
         vat_percentage=Decimal("25.50"),
     )
+    order_id = _make_order(vat_report_event, datetime(2026, 1, 31, 22, 0, tzinfo=UTC), {product.id: 1})
     # UTC moment that is already in February when projected into Europe/Helsinki.
-    _make_order(vat_report_event, datetime(2026, 1, 31, 23, 30, tzinfo=UTC), {product.id: 1})
+    _add_stamp(vat_report_event, order_id, status=PaymentStatus.PAID, when=datetime(2026, 1, 31, 23, 30, tzinfo=UTC))
 
     report = VatByMonth.report(vat_report_event, "en")
     assert [row[0] for row in report.rows] == ["2026-02"]
 
 
 @pytest.mark.django_db
-def test_vat_by_month_report_localized_titles(vat_report_event: Event):
-    """Column titles for VAT rates follow the requested locale's separator."""
-    Product.objects.create(
+def test_vat_by_month_report_paid_then_cancelled_without_refund_stays_a_sale(vat_report_event: Event):
+    """
+    A paid order later cancelled without a refund keeps its money: the sale
+    stays counted and nothing is subtracted as a return.
+    """
+    product = Product.objects.create(
         event=vat_report_event,
         title="Standard",
         description="",
         price=Decimal("125.50"),
         vat_percentage=Decimal("25.50"),
     )
-    _make_order(
+    when = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+    order_id = _make_order(vat_report_event, when, {product.id: 1})
+    _add_stamp(vat_report_event, order_id, status=PaymentStatus.PAID, when=when)
+    _add_stamp(
         vat_report_event,
-        datetime(2026, 3, 15, 12, 0, tzinfo=UTC),
-        {vat_report_event.products.get().id: 1},
+        order_id,
+        status=PaymentStatus.CANCELLED,
+        type=PaymentStampType.CANCEL_WITHOUT_REFUND,
+        when=datetime(2026, 1, 20, 12, 0, tzinfo=UTC),
     )
+
+    report = VatByMonth.report(vat_report_event, "en")
+    assert report.rows == [["2026-01", "25.5%", 125.50, 0.00, 125.50, 25.50]]
+
+
+@pytest.mark.django_db
+def test_vat_by_month_report_duplicate_paid_stamps_count_once(vat_report_event: Event):
+    """
+    A Paytrail payment produces both a redirect and a callback PAID stamp for
+    the same payment. The order's gross must not be double-counted, and the
+    month is decided by the earlier of the two stamps.
+    """
+    product = Product.objects.create(
+        event=vat_report_event,
+        title="Standard",
+        description="",
+        price=Decimal("125.50"),
+        vat_percentage=Decimal("25.50"),
+    )
+    order_id = _make_order(vat_report_event, datetime(2026, 1, 15, 12, 0, tzinfo=UTC), {product.id: 1})
+    _add_stamp(
+        vat_report_event,
+        order_id,
+        status=PaymentStatus.PAID,
+        type=PaymentStampType.PAYMENT_REDIRECT,
+        when=datetime(2026, 1, 15, 12, 0, tzinfo=UTC),
+    )
+    _add_stamp(
+        vat_report_event,
+        order_id,
+        status=PaymentStatus.PAID,
+        type=PaymentStampType.PAYMENT_CALLBACK,
+        when=datetime(2026, 2, 1, 12, 0, tzinfo=UTC),
+    )
+
+    report = VatByMonth.report(vat_report_event, "en")
+    assert report.rows == [["2026-01", "25.5%", 125.50, 0.00, 125.50, 25.50]]
+
+
+@pytest.mark.django_db
+def test_vat_by_month_report_localized_titles(vat_report_event: Event):
+    """The VAT rate cell and the new column titles follow the requested locale."""
+    product = Product.objects.create(
+        event=vat_report_event,
+        title="Standard",
+        description="",
+        price=Decimal("125.50"),
+        vat_percentage=Decimal("25.50"),
+    )
+    when = datetime(2026, 3, 15, 12, 0, tzinfo=UTC)
+    order_id = _make_order(vat_report_event, when, {product.id: 1})
+    _add_stamp(vat_report_event, order_id, status=PaymentStatus.PAID, when=when)
 
     en_report = VatByMonth.report(vat_report_event, "en")
     fi_report = VatByMonth.report(vat_report_event, "fi")
-    # The Column.title is a dict that resolve_localized_field picks from at GraphQL
-    # serialization time; we just verify both locales are populated correctly.
-    vat_col_en = next(c for c in en_report.columns if c.slug == "vat_25.50")
-    vat_col_fi = next(c for c in fi_report.columns if c.slug == "vat_25.50")
-    assert vat_col_en.title["en"] == "25.5%"
-    assert vat_col_fi.title["fi"] == "25,5%"
+
+    assert en_report.rows[0][1] == "25.5%"
+    assert fi_report.rows[0][1] == "25,5%"
+
+    en_titles = {c.slug: c.title for c in en_report.columns}
+    fi_titles = {c.slug: c.title for c in fi_report.columns}
+    assert en_titles["vat_rate"]["en"] == "VAT rate"
+    assert fi_titles["vat_rate"]["fi"] == "ALV-kanta"
+    assert en_titles["sold"]["en"] == "Sold"
+    assert fi_titles["sold"]["fi"] == "Myynti"
+    assert en_titles["returned"]["en"] == "Returned"
+    assert fi_titles["returned"]["fi"] == "Palautukset"
+    assert en_titles["net"]["en"] == "Net"
+    assert fi_titles["net"]["fi"] == "Netto"
+    assert en_titles["vat"]["en"] == "Tax payable"
+    assert fi_titles["vat"]["fi"] == "Maksettava vero"
 
 
 # ---------------------------------------------------------------------------
@@ -658,9 +760,11 @@ def _add_stamp(
     provider: PaymentProvider = PaymentProvider.PAYTRAIL,
     type: PaymentStampType = PaymentStampType.PAYMENT_CALLBACK,
     correlation_id: UUID | None = None,
+    when: datetime | None = None,
 ) -> PaymentStamp:
     stamp = PaymentStamp(
         event=event,
+        id=uuid7(when) if when is not None else uuid7(),
         order_id=order_id,
         correlation_id=correlation_id or uuid7(),
         provider=provider,


### PR DESCRIPTION
Bookkeeping is cash-based: a sale now belongs to the month of its first
PAID payment stamp and a return to the month of its first REFUNDED
stamp, with returns subtracted directly instead of being silently
dropped. The report gains sold/returned/net/vat columns per (month,
VAT rate) row.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
